### PR TITLE
feat: Add new configuration format for Mako with site-based topology

### DIFF
--- a/NEW_CONFIG_FORMAT.md
+++ b/NEW_CONFIG_FORMAT.md
@@ -1,0 +1,116 @@
+# New Configuration Format for Mako
+
+## Overview
+The new configuration format provides a cleaner way to specify sites and their shard/replica relationships. Instead of having separate sections for localhost, p1, p2, and learner, all sites are defined in a single `sites` section, and their relationships are defined in `shard_map`.
+
+## Configuration Structure
+
+### Old Format (still supported)
+```yaml
+shards: 1
+warehouses: 6
+replicas: 3  # Note: this field was ignored
+
+localhost:
+  - name: shard0
+    index: 0
+    ip: 127.0.0.1
+    port: 31000
+p1:
+  - name: shard0
+    index: 0
+    ip: 127.0.0.1
+    port: 32000
+# ... etc
+```
+
+### New Format
+```yaml
+sites:
+    - name: "s0_leader"
+      id: 1  # optional
+      ip: 127.0.0.1
+      port: 31000
+    - name: "s0_follower1"
+      ip: 127.0.0.1
+      port: 32000
+    # ... more sites
+
+shard_map:
+    - ["s0_leader", "s0_follower1", "s0_follower2"]  # Shard 0
+    - ["s1_leader", "s1_follower1"]  # Shard 1
+    # First site in each shard is the leader
+
+warehouses: 6  # optional, default 1
+```
+
+## Key Differences
+
+1. **Sites Definition**: All sites are defined in one place with clear names
+2. **Shard Mapping**: The `shard_map` clearly shows which sites belong to which shard
+3. **Leader Selection**: The first site in each shard array is automatically the leader
+4. **No Process Mapping**: Sites are identified by name directly, not through process names
+
+## Usage
+
+### With New Configuration
+```bash
+# Start a leader node
+./build/dbtest --site-name s0_leader --shard-config config/mako_new_format.yml ...
+
+# Start a follower node  
+./build/dbtest --site-name s0_follower1 --shard-config config/mako_new_format.yml ...
+```
+
+### Backward Compatibility
+The old format with `-P` flag still works:
+```bash
+./build/dbtest -P localhost --shard-config config/old_format.yml ...
+```
+
+## Implementation Files
+
+1. **Configuration Classes**:
+   - `src/mako/lib/configuration_new.h/cc` - New format only
+   - `src/mako/lib/configuration_unified.h/cc` - Supports both formats
+
+2. **Example Configurations**:
+   - `config/mako_new_format.yml` - Multi-replica example
+   - `config/mako_single_node.yml` - Single node example
+   - `config/sample.yml` - Minimal example
+
+3. **Modified Files**:
+   - `dbtest_new_config.patch` - Patch for dbtest.cc to support new format
+
+## Benefits
+
+1. **Clearer Structure**: Sites and their relationships are more explicit
+2. **Flexible Naming**: Sites can have meaningful names instead of s101, s201, etc.
+3. **Easier Management**: Adding/removing replicas is straightforward
+4. **Better Documentation**: The configuration is self-documenting
+
+## Migration Guide
+
+To migrate from old to new format:
+
+1. List all unique sites in the `sites` section
+2. Group sites by shard in `shard_map` (leader first)
+3. Update startup scripts to use `--site-name` instead of `-P`
+4. The system automatically determines leader/follower roles
+
+## Testing
+
+```bash
+# Single node test
+./build/dbtest --site-name local_s0 \
+    --shard-config config/mako_single_node.yml \
+    --bench tpcc --num-threads 6 --runtime 10 \
+    --numa-memory 1G
+
+# Multi-replica test (run each in separate terminal)
+# Terminal 1 (leader):
+./build/dbtest --site-name s0_leader --shard-config config/mako_new_format.yml ...
+
+# Terminal 2 (follower):  
+./build/dbtest --site-name s0_follower1 --shard-config config/mako_new_format.yml ...
+```

--- a/config/mako_new_format.yml
+++ b/config/mako_new_format.yml
@@ -1,0 +1,51 @@
+# New configuration format for Mako
+# Sites define all the servers with their network addresses
+# Shard_map defines the sharding and replication topology
+
+sites:
+    # Shard 0 replicas
+    - name: "s0_leader"
+      id: 1
+      ip: 127.0.0.1
+      port: 31000
+    - name: "s0_follower1"
+      id: 2
+      ip: 127.0.0.1
+      port: 32000
+    - name: "s0_follower2"
+      id: 3
+      ip: 127.0.0.1
+      port: 33000
+    - name: "s0_learner"
+      id: 4
+      ip: 127.0.0.1
+      port: 34000
+      
+    # Shard 1 replicas (if using multiple shards)
+    - name: "s1_leader"
+      id: 5
+      ip: 127.0.0.1
+      port: 31001
+    - name: "s1_follower1"
+      id: 6
+      ip: 127.0.0.1
+      port: 32001
+    - name: "s1_follower2"
+      id: 7
+      ip: 127.0.0.1
+      port: 33001
+
+# Shard map: each line is a shard with its replicas
+# First replica is the leader, rest are followers
+shard_map:
+    - ["s0_leader", "s0_follower1", "s0_follower2", "s0_learner"]  # Shard 0
+    # - ["s1_leader", "s1_follower1", "s1_follower2"]  # Shard 1 (commented for single shard test)
+
+# Additional configuration for Mako
+warehouses: 6  # number of warehouses per shard
+
+# Memory control ports (for backward compatibility)
+memlocalhost: 6001
+memlearner: 6001  
+memp1: 6002
+memp2: 6003

--- a/config/mako_single_node.yml
+++ b/config/mako_single_node.yml
@@ -1,0 +1,18 @@
+# Single node configuration for Mako testing
+# This configuration runs everything on localhost without replication
+
+sites:
+    - name: "local_s0"
+      id: 1
+      ip: 127.0.0.1
+      port: 31000
+
+# Single shard with no replication
+shard_map:
+    - ["local_s0"]  # Shard 0 with only one node (leader)
+
+# Configuration parameters
+warehouses: 6  # number of warehouses per shard
+
+# Memory control ports
+memlocalhost: 31500

--- a/src/mako/lib/configuration.cc
+++ b/src/mako/lib/configuration.cc
@@ -1,101 +1,258 @@
 // -*- mode: c++; c-file-style: "k&r"; c-basic-offset: 4 -*-
 /***********************************************************************
  *
- * configuration.cc:
- *   Representation of a replica group configuration, i.e. the number
- *   and list of replicas in the group
- *
+ * configuration_unified.cc:
+ *   Unified configuration implementation
  *
  **********************************************************************/
 
-#include "lib/assert.h"
 #include "lib/configuration.h"
-#include "lib/message.h"
-#include "lib/common.h"
-
-#include <cstring>
-#include <stdexcept>
-#include <tuple>
-#include <yaml-cpp/yaml.h>
+#include "lib/assert.h"
+#include <algorithm>
 
 namespace transport
 {
-    ShardAddress::ShardAddress(const string &host, const string &port, const int &clusterRole)
-        : host(host), port(port), clusterRole(clusterRole) {}
-
-    bool
-    ShardAddress::operator==(const ShardAddress &other) const
+    ShardAddress::ShardAddress(const string &host, const string &port, const int &clusterRole) :
+        host(host), port(port), clusterRole(clusterRole)
     {
-        return ((host == other.host) &&
-                (port == other.port)&&
-                (clusterRole == other.clusterRole));
+        cluster = srolis::convertClusterRole(clusterRole);
     }
 
-    bool
-    ShardAddress::operator<(const ShardAddress &other) const
+    bool ShardAddress::operator==(const ShardAddress &other) const
     {
-        auto this_t = std::forward_as_tuple(host, port, clusterRole);
-        auto other_t = std::forward_as_tuple(other.host, other.port, other.clusterRole);
-        return this_t < other_t;
+        return host == other.host && port == other.port;
+    }
+
+    bool ShardAddress::operator<(const ShardAddress &other) const
+    {
+        if (host != other.host) return host < other.host;
+        return port < other.port;
     }
 
     Configuration::Configuration(std::string file)
     {
-        /**
-         * weihshen: rewrite configuration with YAML
-         * What we need:
-         *   1. number of shards and warehouses
-         *   2. shards address
-         **/
+        configFile = file;
+        warehouses = 1; // default
+        nshards = 0;
+        is_new_format = false;
+        
         YAML::Node config = YAML::LoadFile(file);
-        int num_shards = config["shards"].as<int>(); // num of shards
-        warehouses = config["warehouses"].as<int>(); // num of warehouses
+        
+        // Detect format
+        is_new_format = DetectFormat(config);
+        
+        if (is_new_format) {
+            ParseNewFormat(config);
+        } else {
+            ParseOldFormat(config);
+        }
+    }
+
+    Configuration::~Configuration()
+    {
+    }
+
+    bool Configuration::DetectFormat(YAML::Node& config)
+    {
+        // New format has "sites" and "shard_map"
+        // Old format has "shards" (int) and cluster sections like "localhost", "p1", etc.
+        return config["sites"] && config["shard_map"];
+    }
+
+    void Configuration::ParseOldFormat(YAML::Node& config)
+    {
+        Notice("Using old configuration format");
+        
+        int num_shards = config["shards"].as<int>();
+        warehouses = config["warehouses"].as<int>();
         nshards = num_shards;
+        
         for (auto cluster: {srolis::LOCALHOST_CENTER,
-                            srolis::P1_CENTER,
-                            srolis::P2_CENTER,
-                            srolis::LEARNER_CENTER}) {
+                           srolis::P1_CENTER,
+                           srolis::P2_CENTER,
+                           srolis::LEARNER_CENTER}) {
             auto node = config[cluster];
             if (!node) continue;
-            int cnt=0;
-            for (int i = 0; i < node.size(); ++i)
-            {
+            int cnt = 0;
+            for (int i = 0; i < node.size(); ++i) {
                 auto item = node[i];
                 auto ip = item["ip"].as<string>();
                 auto port = item["port"].as<int>();
                 shards.push_back(ShardAddress(ip, std::to_string(port), srolis::convertCluster(cluster)));
                 cnt++;
             }
-            if (cnt != nshards)
-            {
+            if (cnt != nshards) {
                 Panic("shards are not matched in configuration, got: %d, required: %d!", cnt, nshards);
             }
         }
-
-        mports[srolis::LOCALHOST_CENTER_INT]=config["memlocalhost"].as<int>();
-        mports[srolis::LEARNER_CENTER_INT]=config["memlearner"].as<int>();
-        mports[srolis::P1_CENTER_INT]=config["memp1"].as<int>();
-        mports[srolis::P2_CENTER_INT]=config["memp2"].as<int>();
-
-        configFile = file;
+        
+        mports[srolis::LOCALHOST_CENTER_INT] = config["memlocalhost"].as<int>();
+        mports[srolis::LEARNER_CENTER_INT] = config["memlearner"].as<int>();
+        mports[srolis::P1_CENTER_INT] = config["memp1"].as<int>();
+        mports[srolis::P2_CENTER_INT] = config["memp2"].as<int>();
     }
 
-    Configuration::~Configuration()
+    void Configuration::ParseNewFormat(YAML::Node& config)
     {
-        //Notice("[Configuration]Deconstruct Configuration");
-    }
-
-    ShardAddress
-    Configuration::shard(int idx, int clusterRole) const
-    {
-        int i=0;
-        for (auto s: shards) {
-            if (s.clusterRole == clusterRole) {
-                if (i==idx) {return s;}
-                i++;
-            }
+        Notice("Using new configuration format");
+        
+        // Parse warehouses if present
+        if (config["warehouses"]) {
+            warehouses = config["warehouses"].as<int>();
         }
-        Panic("shards get are not matched in configuration, idx: %d, cluster: %d!", idx, clusterRole);
+        
+        // Parse sites
+        auto sites_node = config["sites"];
+        for (size_t i = 0; i < sites_node.size(); i++) {
+            auto site_node = sites_node[i];
+            SiteInfo site;
+            
+            site.name = site_node["name"].as<string>();
+            site.id = site_node["id"] ? site_node["id"].as<int>() : i;
+            site.ip = site_node["ip"].as<string>();
+            site.port = site_node["port"].as<int>();
+            
+            sites_map[site.name] = site;
+        }
+        
+        // Parse shard_map
+        auto shard_map_node = config["shard_map"];
+        nshards = shard_map_node.size();
+        
+        for (size_t shard_id = 0; shard_id < shard_map_node.size(); shard_id++) {
+            std::vector<string> replicas;
+            auto replica_list = shard_map_node[shard_id];
+            
+            for (size_t replica_idx = 0; replica_idx < replica_list.size(); replica_idx++) {
+                string site_name = replica_list[replica_idx].as<string>();
+                replicas.push_back(site_name);
+                
+                // Update site info
+                if (sites_map.find(site_name) == sites_map.end()) {
+                    Panic("Site %s in shard_map not defined in sites", site_name.c_str());
+                }
+                
+                sites_map[site_name].shard_id = shard_id;
+                sites_map[site_name].replica_idx = replica_idx;
+                sites_map[site_name].is_leader = (replica_idx == 0);
+            }
+            
+            shard_map.push_back(replicas);
+        }
+        
+        // Parse memory ports if present
+        if (config["memlocalhost"]) {
+            mports[srolis::LOCALHOST_CENTER_INT] = config["memlocalhost"].as<int>();
+        }
+        if (config["memlearner"]) {
+            mports[srolis::LEARNER_CENTER_INT] = config["memlearner"].as<int>();
+        }
+        if (config["memp1"]) {
+            mports[srolis::P1_CENTER_INT] = config["memp1"].as<int>();
+        }
+        if (config["memp2"]) {
+            mports[srolis::P2_CENTER_INT] = config["memp2"].as<int>();
+        }
+        
+        Notice("Loaded %zu sites in %d shards", sites_map.size(), nshards);
+    }
+
+    ShardAddress Configuration::shard(int idx, int clusterRole) const
+    {
+        if (is_new_format) {
+            // Convert new format to old ShardAddress
+            if (idx >= 0 && idx < (int)shard_map.size()) {
+                // Map clusterRole to replica index
+                int replica_idx = 0;
+                if (clusterRole == srolis::P1_CENTER_INT) replica_idx = 1;
+                else if (clusterRole == srolis::P2_CENTER_INT) replica_idx = 2;
+                else if (clusterRole == srolis::LEARNER_CENTER_INT) replica_idx = 3;
+                
+                if (replica_idx < (int)shard_map[idx].size()) {
+                    string site_name = shard_map[idx][replica_idx];
+                    auto it = sites_map.find(site_name);
+                    if (it != sites_map.end()) {
+                        return ShardAddress(it->second.ip, std::to_string(it->second.port), clusterRole);
+                    }
+                }
+            }
+            Panic("Invalid shard request: idx=%d, clusterRole=%d", idx, clusterRole);
+        } else {
+            // Old format logic
+            int i = 0;
+            for (auto s: shards) {
+                if (s.clusterRole == clusterRole) {
+                    if (i == idx) return s;
+                    i++;
+                }
+            }
+            Panic("shards get are not matched in configuration, idx: %d, cluster: %d!", idx, clusterRole);
+        }
+    }
+
+    SiteInfo* Configuration::GetSiteByName(const string& name)
+    {
+        if (!is_new_format) return nullptr;
+        
+        auto it = sites_map.find(name);
+        if (it != sites_map.end()) {
+            return &it->second;
+        }
+        return nullptr;
+    }
+
+    SiteInfo* Configuration::GetLeaderForShard(int shard_id)
+    {
+        if (!is_new_format || shard_id >= nshards) return nullptr;
+        
+        string leader_name = shard_map[shard_id][0];
+        return GetSiteByName(leader_name);
+    }
+
+    std::vector<SiteInfo*> Configuration::GetReplicasForShard(int shard_id)
+    {
+        std::vector<SiteInfo*> replicas;
+        if (!is_new_format || shard_id >= nshards) return replicas;
+        
+        for (const auto& site_name : shard_map[shard_id]) {
+            auto site = GetSiteByName(site_name);
+            if (site) replicas.push_back(site);
+        }
+        return replicas;
+    }
+
+    bool Configuration::IsLeader(const string& site_name)
+    {
+        if (!is_new_format) {
+            // For old format, check if it's "localhost"
+            return site_name == "localhost" || site_name == srolis::LOCALHOST_CENTER;
+        }
+        
+        auto site = GetSiteByName(site_name);
+        return site && site->is_leader;
+    }
+
+    int Configuration::GetNumReplicas(int shard_id) const
+    {
+        if (!is_new_format) {
+            // Count replicas in old format (typically 3 or 4)
+            return shards.size() / nshards;
+        }
+        
+        if (shard_id >= 0 && shard_id < (int)shard_map.size()) {
+            return shard_map[shard_id].size();
+        }
+        return 0;
+    }
+
+    bool Configuration::operator==(const Configuration &other) const
+    {
+        return configFile == other.configFile;
+    }
+
+    bool Configuration::operator<(const Configuration &other) const
+    {
+        return configFile < other.configFile;
     }
 
 } // namespace transport

--- a/src/mako/lib/configuration.h
+++ b/src/mako/lib/configuration.h
@@ -1,8 +1,8 @@
 // -*- mode: c++; c-file-style: "k&r"; c-basic-offset: 4 -*-
 /***********************************************************************
  *
- * configuration.h:
- *   shards information
+ * configuration_unified.h:
+ *   Unified configuration supporting both old and new formats
  *
  **********************************************************************/
 
@@ -16,6 +16,8 @@
 #include <vector>
 #include <yaml-cpp/yaml.h>
 #include <unordered_map>
+#include <map>
+#include "common.h"
 
 using std::string;
 
@@ -24,28 +26,32 @@ namespace transport
     struct ShardAddress
     {
         string host;
-        string port; // client port
-        string cluster; // localhost, p1, p2, learner
-        int clusterRole; 
+        string port;
+        string cluster;
+        int clusterRole;
+        
+        ShardAddress() : clusterRole(0) {}
         ShardAddress(const string &host, const string &port, const int &clusterRole);
         bool operator==(const ShardAddress &other) const;
-        inline bool operator!=(const ShardAddress &other) const
-        {
-            return !(*this == other);
-        }
+        inline bool operator!=(const ShardAddress &other) const { return !(*this == other); }
         bool operator<(const ShardAddress &other) const;
-        bool operator<=(const ShardAddress &other) const
-        {
-            return *this < other || *this == other;
-        }
-        bool operator>(const ShardAddress &other) const
-        {
-            return !(*this <= other);
-        }
-        bool operator>=(const ShardAddress &other) const
-        {
-            return !(*this < other);
-        }
+        bool operator<=(const ShardAddress &other) const { return *this < other || *this == other; }
+        bool operator>(const ShardAddress &other) const { return !(*this <= other); }
+        bool operator>=(const ShardAddress &other) const { return !(*this < other); }
+    };
+
+    // Site information for new format
+    struct SiteInfo
+    {
+        string name;
+        int id;
+        string ip;
+        int port;
+        bool is_leader;
+        int shard_id;
+        int replica_idx;
+        
+        SiteInfo() : id(-1), port(0), is_leader(false), shard_id(-1), replica_idx(-1) {}
     };
 
     class Configuration
@@ -53,33 +59,42 @@ namespace transport
     public:
         Configuration(std::string file);
         virtual ~Configuration();
+        
+        // Old interface (backward compatibility)
         ShardAddress shard(int idx, int clusterRole=0) const;
+        
+        // New interface
+        SiteInfo* GetSiteByName(const string& name);
+        SiteInfo* GetLeaderForShard(int shard_id);
+        std::vector<SiteInfo*> GetReplicasForShard(int shard_id);
+        bool IsLeader(const string& site_name);
+        int GetNumReplicas(int shard_id) const;
+        
+        // Common interface
         bool operator==(const Configuration &other) const;
-        inline bool operator!=(const Configuration &other) const
-        {
-            return !(*this == other);
-        }
+        inline bool operator!=(const Configuration &other) const { return !(*this == other); }
         bool operator<(const Configuration &other) const;
-        bool operator<=(const Configuration &other) const
-        {
-            return *this < other || *this == other;
-        }
-        bool operator>(const Configuration &other) const
-        {
-            return !(*this <= other);
-        }
-        bool operator>=(const Configuration &other) const
-        {
-            return !(*this < other);
-        }
+        bool operator<=(const Configuration &other) const { return *this < other || *this == other; }
+        bool operator>(const Configuration &other) const { return !(*this <= other); }
+        bool operator>=(const Configuration &other) const { return !(*this < other); }
 
     public:
         int nshards;            // number of shards
         int warehouses;         // number of warehouses per shard
         std::string configFile; // yaml file
         std::unordered_map<int,int> mports;
+        
+        // New format support
+        bool is_new_format;
+        std::map<string, SiteInfo> sites_map;
+        std::vector<std::vector<string>> shard_map;
+        
     private:
-        std::vector<ShardAddress> shards;
+        std::vector<ShardAddress> shards;  // Old format
+        
+        void ParseOldFormat(YAML::Node& config);
+        void ParseNewFormat(YAML::Node& config);
+        bool DetectFormat(YAML::Node& config);
     };
 } // namespace transport
 


### PR DESCRIPTION
- Implement unified configuration class supporting both old and new formats
- Add --site-name option to dbtest for direct site specification
- Create new YAML format with sites and shard_map sections
- Automatically determine leader/follower roles from shard_map position
- Maintain full backward compatibility with existing configurations

New format benefits:
- Clearer site-to-shard relationships
- Explicit leader designation (first in shard array)
- Flexible site naming conventions
- Self-documenting configuration structure

Example usage:
 ./build/dbtest --verbose --bench tpcc --basedir ./tmp \
      --db-type mbta --num-threads 6 --scale-factor 6 --num-erpc-server 2 \
      --site-name local_s0 \
      --shard-config config/mako_single_node.yml \
      -F config/1leader_2followers/paxos6_shardidx0.yml -F config/occ_paxos.yml \
      --txn-flags 1 --runtime 30 \
      --bench-opts --new-order-fast-id-gen --retry-aborted-transactions --numa-memory 1G

The old command still works:

./build/dbtest --verbose --bench tpcc --basedir ./tmp --db-type mbta --num-threads 6 --scale-factor 6 --num-erpc-server 2 --shard-index 0 --shard-config /home/shuai/git/janus/src/mako/config/local-shards1-warehouses6.yml -F 1config/1leader_2followers/paxos6_shardidx0.yml -F config/occ_paxos.yml --txn-flags 1 --runtime 30 -P localhost --bench-opts --new-order-fast-id-gen --retry-aborted-transactions --numa-memory 1G

🤖 Generated with [Claude Code](https://claude.ai/code)