### PR TITLE
chore(rust): upgrade rust version 1.80 -> 1.91

### DIFF
--- a/install_rustc.sh
+++ b/install_rustc.sh
@@ -1,14 +1,14 @@
 cd $HOME 
 
-curl -LO https://static.rust-lang.org/dist/rust-1.80.0-x86_64-unknown-linux-gnu.tar.gz
+curl -LO https://static.rust-lang.org/dist/rust-1.91.0-x86_64-unknown-linux-gnu.tar.gz
 
-tar xzf rust-1.80.0-x86_64-unknown-linux-gnu.tar.gz
+tar xzf rust-1.91.0-x86_64-unknown-linux-gnu.tar.gz
 
-cd $HOME/rust-1.80.0-x86_64-unknown-linux-gnu/
+cd $HOME/rust-1.91.0-x86_64-unknown-linux-gnu/
 
 mkdir -p $HOME/.local-rust
 
-$HOME/rust-1.80.0-x86_64-unknown-linux-gnu/install.sh --prefix=$HOME/.local-rust
+$HOME/rust-1.91.0-x86_64-unknown-linux-gnu/install.sh --prefix=$HOME/.local-rust
 
 
 if [ -f "$HOME/.bashrc" ]; then


### PR DESCRIPTION
there are some cargos which depend on v1.80+
@shuaimu @shenweihai1 also any reason why we dont install rust from rustup?