### PR TITLE
patch(tests): add runtime flag for running tests in defined runtime

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -3,6 +3,15 @@
 
 set -e  # Exit on error
 
+# Minimal optional flag: --runtime <seconds>
+if [[ "${1:-}" == "--runtime" ]]; then
+    export CI_RUNTIME_SEC="${2:-}"
+    shift 2
+elif [[ "${1:-}" == --runtime=* ]]; then
+    export CI_RUNTIME_SEC="${1#*=}"
+    shift 1
+fi
+
 # Function to check for hanging processes after a test
 check_for_hanging_processes() {
     local test_name="$1"

--- a/examples/test_1shard_no_replication.sh
+++ b/examples/test_1shard_no_replication.sh
@@ -24,8 +24,13 @@ SHARD0_PID=$!
 sleep 2
 
 # Wait for experiments to run
-echo "Running experiments for 15 seconds..."
-sleep 35
+if [ -n "${CI_RUNTIME_SEC}" ]; then
+    echo "Running experiments for ${CI_RUNTIME_SEC} seconds..."
+    sleep $((CI_RUNTIME_SEC + 20))
+else
+    echo "Running experiments for 15 seconds..."
+    sleep 35
+fi
 
 # Kill the processes
 echo "Stopping shards..."

--- a/examples/test_1shard_replication.sh
+++ b/examples/test_1shard_replication.sh
@@ -30,8 +30,13 @@ SHARD0_PID=$!
 sleep 2
 
 # Wait for experiments to run
-echo "Running experiments for 15 seconds..."
-sleep 45
+if [ -n "${CI_RUNTIME_SEC}" ]; then
+    echo "Running experiments for ${CI_RUNTIME_SEC} seconds..."
+    sleep $((CI_RUNTIME_SEC + 30))
+else
+    echo "Running experiments for 15 seconds..."
+    sleep 45
+fi
 
 # Kill the processes
 echo "Stopping shards..."

--- a/examples/test_2shard_no_replication.sh
+++ b/examples/test_2shard_no_replication.sh
@@ -33,8 +33,13 @@ nohup bash bash/shard.sh 2 1 $trd localhost > ${log_prefix}_shard1-$trd.log 2>&1
 SHARD1_PID=$!
 
 # Wait for experiments to run
-echo "Running experiments for 15 seconds..."
-sleep 35
+if [ -n "${CI_RUNTIME_SEC}" ]; then
+    echo "Running experiments for ${CI_RUNTIME_SEC} seconds..."
+    sleep $((CI_RUNTIME_SEC + 20))
+else
+    echo "Running experiments for 15 seconds..."
+    sleep 35
+fi
 
 # Kill the processes
 echo "Stopping shards..."

--- a/examples/test_2shard_no_replication_simple.sh
+++ b/examples/test_2shard_no_replication_simple.sh
@@ -31,7 +31,11 @@ SHARD1_PID=$!
 
 # Wait for experiments to run
 echo "Running experiments"
-sleep 20
+if [ -n "${CI_RUNTIME_SEC}" ]; then
+    sleep $((CI_RUNTIME_SEC + 5))
+else
+    sleep 20
+fi
 
 # Kill the processes
 echo "Stopping shards..."

--- a/examples/test_2shard_replication.sh
+++ b/examples/test_2shard_replication.sh
@@ -54,8 +54,13 @@ nohup bash bash/shard.sh 2 1 $trd p1 0 1 > ${log_prefix}_shard1-p1.log 2>&1 &
 SHARD1_P1_PID=$!
 
 # Wait for experiments to run
-echo "Running experiments for 15 seconds..."
-sleep 45
+if [ -n "${CI_RUNTIME_SEC}" ]; then
+    echo "Running experiments for ${CI_RUNTIME_SEC} seconds..."
+    sleep $((CI_RUNTIME_SEC + 30))
+else
+    echo "Running experiments for 15 seconds..."
+    sleep 45
+fi
 
 # Kill the processes - FORCE KILL ALL
 echo "Stopping shards..."

--- a/examples/test_2shard_replication_simple.sh
+++ b/examples/test_2shard_replication_simple.sh
@@ -47,7 +47,11 @@ PID_S1_P1=$!
 
 # Wait for experiments to run
 echo "Running experiments"
-sleep 30
+if [ -n "${CI_RUNTIME_SEC}" ]; then
+    sleep $((CI_RUNTIME_SEC + 15))
+else
+    sleep 30
+fi
 
 # Kill ALL processes from both shards
 echo "Stopping shards..."


### PR DESCRIPTION
This closes #35 last comment for machines having low specs and gives user flexibility for running tests. 