### PR TITLE
Masstree Safety: Pointer-to-reference conversions and safety annotations

### DIFF
--- a/src/mako/benchmarks/sto/masstree-beta/checkpoint.hh
+++ b/src/mako/benchmarks/sto/masstree-beta/checkpoint.hh
@@ -48,7 +48,7 @@ void ckstate::insert(T& table, msgpack::parser& par, threadinfo& ti) {
     typename T::cursor_type lp(table, key);
     bool found = lp.find_insert(ti);
     masstree_invariant(!found); (void) found;
-    ti.observe_phantoms(lp.node());
+    ti.observe_phantoms(*lp.node());
     lp.value() = row;
     lp.finish(1, ti);
 }

--- a/src/mako/benchmarks/sto/masstree-beta/checkpoint.hh
+++ b/src/mako/benchmarks/sto/masstree-beta/checkpoint.hh
@@ -48,7 +48,7 @@ void ckstate::insert(T& table, msgpack::parser& par, threadinfo& ti) {
     typename T::cursor_type lp(table, key);
     bool found = lp.find_insert(ti);
     masstree_invariant(!found); (void) found;
-    ti.observe_phantoms(*lp.node());
+    ti.observe_phantoms(lp.node());
     lp.value() = row;
     lp.finish(1, ti);
 }

--- a/src/mako/benchmarks/sto/masstree-beta/kvrow.hh
+++ b/src/mako/benchmarks/sto/masstree-beta/kvrow.hh
@@ -166,7 +166,7 @@ result_t query<R>::run_put(T& table, Str key,
     typename T::cursor_type lp(table, key);
     bool found = lp.find_insert(ti);
     if (!found)
-        ti.observe_phantoms(*lp.node());
+        ti.observe_phantoms(lp.node());
     bool inserted = apply_put(lp.value(), found, firstreq, lastreq, ti);
     lp.finish(1, ti);
     return inserted ? Inserted : Updated;
@@ -207,7 +207,7 @@ result_t query<R>::run_replace(T& table, Str key, Str value, threadinfo& ti) {
     typename T::cursor_type lp(table, key);
     bool found = lp.find_insert(ti);
     if (!found)
-        ti.observe_phantoms(*lp.node());
+        ti.observe_phantoms(lp.node());
     bool inserted = apply_replace(lp.value(), found, value, ti);
     lp.finish(1, ti);
     return inserted ? Inserted : Updated;

--- a/src/mako/benchmarks/sto/masstree-beta/kvrow.hh
+++ b/src/mako/benchmarks/sto/masstree-beta/kvrow.hh
@@ -166,7 +166,7 @@ result_t query<R>::run_put(T& table, Str key,
     typename T::cursor_type lp(table, key);
     bool found = lp.find_insert(ti);
     if (!found)
-        ti.observe_phantoms(lp.node());
+        ti.observe_phantoms(*lp.node());
     bool inserted = apply_put(lp.value(), found, firstreq, lastreq, ti);
     lp.finish(1, ti);
     return inserted ? Inserted : Updated;
@@ -207,7 +207,7 @@ result_t query<R>::run_replace(T& table, Str key, Str value, threadinfo& ti) {
     typename T::cursor_type lp(table, key);
     bool found = lp.find_insert(ti);
     if (!found)
-        ti.observe_phantoms(lp.node());
+        ti.observe_phantoms(*lp.node());
     bool inserted = apply_replace(lp.value(), found, value, ti);
     lp.finish(1, ti);
     return inserted ? Inserted : Updated;

--- a/src/mako/benchmarks/sto/masstree-beta/kvthread.hh
+++ b/src/mako/benchmarks/sto/masstree-beta/kvthread.hh
@@ -117,10 +117,9 @@ class threadinfo {
             ts_ = (x | 1) + 1;
         return ts_;
     }
-    // @safe - pure timestamp comparison and assignment
-    template <typename N> void observe_phantoms(const N& n) {
-        if (circular_int<kvtimestamp_t>::less(ts_, n.phantom_epoch_[0]))
-            ts_ = n.phantom_epoch_[0];
+    template <typename N> void observe_phantoms(N* n) {
+        if (circular_int<kvtimestamp_t>::less(ts_, n->phantom_epoch_[0]))
+            ts_ = n->phantom_epoch_[0];
     }
 
     // event counters

--- a/src/mako/benchmarks/sto/masstree-beta/kvthread.hh
+++ b/src/mako/benchmarks/sto/masstree-beta/kvthread.hh
@@ -117,9 +117,10 @@ class threadinfo {
             ts_ = (x | 1) + 1;
         return ts_;
     }
-    template <typename N> void observe_phantoms(N* n) {
-        if (circular_int<kvtimestamp_t>::less(ts_, n->phantom_epoch_[0]))
-            ts_ = n->phantom_epoch_[0];
+    // @safe - pure timestamp comparison and assignment
+    template <typename N> void observe_phantoms(const N& n) {
+        if (circular_int<kvtimestamp_t>::less(ts_, n.phantom_epoch_[0]))
+            ts_ = n.phantom_epoch_[0];
     }
 
     // event counters

--- a/src/mako/masstree/btree_leaflink.hh
+++ b/src/mako/masstree/btree_leaflink.hh
@@ -33,20 +33,22 @@ template <typename N, bool CONCURRENT = N::concurrent> struct btree_leaflink {};
 // operations.
 template <typename N> struct btree_leaflink<N, true> {
   private:
+    // @safe - pure pointer arithmetic (marker bit)
     static inline N *mark(N *n) {
         return reinterpret_cast<N *>(reinterpret_cast<uintptr_t>(n) + 1);
     }
+    // @safe - pure pointer value check
     static inline bool is_marked(N *n) {
         return reinterpret_cast<uintptr_t>(n) & 1;
     }
     template <typename SF>
     // @unsafe - manipulates raw next pointers with CAS
-    static inline N *lock_next(N *n, SF spin_function) {
+    static inline N *lock_next(N &n, SF spin_function) {
         while (1) {
-            N *next = n->next_.ptr;
+            N *next = n.next_.ptr;
             if (!next
                 || (!is_marked(next)
-                    && bool_cmpxchg(&n->next_.ptr, next, mark(next))))
+                    && bool_cmpxchg(&n.next_.ptr, next, mark(next))))
                 return next;
             spin_function();
         }
@@ -59,20 +61,20 @@ template <typename N> struct btree_leaflink<N, true> {
         Concurrency correctness: Ensures that all "next" pointers are always
         valid, even if @a n's successor is deleted concurrently. */
     // @unsafe - mutates linked list pointers without borrow tracking
-    // @unsafe - raw pointer rewiring without concurrency support
-    static void link_split(N *n, N *nr) {
+    static void link_split(N &n, N &nr) {
         link_split(n, nr, relax_fence_function());
     }
     /** @overload */
     template <typename SF>
-    static void link_split(N *n, N *nr, SF spin_function) {
-        nr->prev_ = n;
+    // @unsafe - raw pointer rewiring with CAS operations
+    static void link_split(N &n, N &nr, SF spin_function) {
+        nr.prev_ = &n;
         N *next = lock_next(n, spin_function);
-        nr->next_.ptr = next;
+        nr.next_.ptr = next;
         if (next)
-            next->prev_ = nr;
+            next->prev_ = &nr;
         fence();
-        n->next_.ptr = nr;
+        n.next_.ptr = &nr;
     }
 
     /** @brief Unlink @a n from the list.
@@ -81,20 +83,20 @@ template <typename N> struct btree_leaflink<N, true> {
         Concurrency correctness: Works even in the presence of concurrent
         splits and deletes. */
     // @unsafe - rewires prev/next pointers of raw leaves
-    // @unsafe - raw unlink operation
-    static void unlink(N *n) {
+    static void unlink(N &n) {
         unlink(n, relax_fence_function());
     }
     /** @overload */
     template <typename SF>
-    static void unlink(N *n, SF spin_function) {
+    // @unsafe - raw unlink operation with CAS
+    static void unlink(N &n, SF spin_function) {
         // Assume node order A <-> N <-> B. Since n is locked, n cannot split;
         // next node will always be B or one of its successors.
         N *next = lock_next(n, spin_function);
         N *prev;
         while (1) {
-            prev = n->prev_;
-            if (bool_cmpxchg(&prev->next_.ptr, n, mark(n)))
+            prev = n.prev_;
+            if (bool_cmpxchg(&prev->next_.ptr, &n, mark(&n)))
                 break;
             spin_function();
         }
@@ -108,25 +110,29 @@ template <typename N> struct btree_leaflink<N, true> {
 
 // This is the single-threaded-only fast version of btree_leaflink.
 template <typename N> struct btree_leaflink<N, false> {
-    static void link_split(N *n, N *nr) {
+    // @unsafe - address-of operations on references for linked list pointers
+    static void link_split(N &n, N &nr) {
         link_split(n, nr, do_nothing());
     }
     template <typename SF>
-    static void link_split(N *n, N *nr, SF) {
-        nr->prev_ = n;
-        nr->next_.ptr = n->next_.ptr;
-        n->next_.ptr = nr;
-        if (nr->next_.ptr)
-            nr->next_.ptr->prev_ = nr;
+    // @unsafe - address-of operations on references for linked list pointers
+    static void link_split(N &n, N &nr, SF) {
+        nr.prev_ = &n;
+        nr.next_.ptr = n.next_.ptr;
+        n.next_.ptr = &nr;
+        if (nr.next_.ptr)
+            nr.next_.ptr->prev_ = &nr;
     }
-    static void unlink(N *n) {
+    // @unsafe - delegates to unsafe unlink with spin function
+    static void unlink(N &n) {
         unlink(n, do_nothing());
     }
     template <typename SF>
-    static void unlink(N *n, SF) {
-        if (n->next_.ptr)
-            n->next_.ptr->prev_ = n->prev_;
-        n->prev_->next_.ptr = n->next_.ptr;
+    // @unsafe - raw pointer dereferences for linked list traversal
+    static void unlink(N &n, SF) {
+        if (n.next_.ptr)
+            n.next_.ptr->prev_ = n.prev_;
+        n.prev_->next_.ptr = n.next_.ptr;
     }
 };
 

--- a/src/mako/masstree/btree_leaflink.hh
+++ b/src/mako/masstree/btree_leaflink.hh
@@ -33,11 +33,11 @@ template <typename N, bool CONCURRENT = N::concurrent> struct btree_leaflink {};
 // operations.
 template <typename N> struct btree_leaflink<N, true> {
   private:
-    // @safe - pure pointer arithmetic (marker bit)
+    // @unsafe - uses reinterpret_cast for pointer tagging
     static inline N *mark(N *n) {
         return reinterpret_cast<N *>(reinterpret_cast<uintptr_t>(n) + 1);
     }
-    // @safe - pure pointer value check
+    // @unsafe - uses reinterpret_cast for pointer tagging
     static inline bool is_marked(N *n) {
         return reinterpret_cast<uintptr_t>(n) & 1;
     }

--- a/src/mako/masstree/btree_leaflink.hh
+++ b/src/mako/masstree/btree_leaflink.hh
@@ -43,12 +43,12 @@ template <typename N> struct btree_leaflink<N, true> {
     }
     template <typename SF>
     // @unsafe - manipulates raw next pointers with CAS
-    static inline N *lock_next(N &n, SF spin_function) {
+    static inline N *lock_next(N *n, SF spin_function) {
         while (1) {
-            N *next = n.next_.ptr;
+            N *next = n->next_.ptr;
             if (!next
                 || (!is_marked(next)
-                    && bool_cmpxchg(&n.next_.ptr, next, mark(next))))
+                    && bool_cmpxchg(&n->next_.ptr, next, mark(next))))
                 return next;
             spin_function();
         }
@@ -61,20 +61,20 @@ template <typename N> struct btree_leaflink<N, true> {
         Concurrency correctness: Ensures that all "next" pointers are always
         valid, even if @a n's successor is deleted concurrently. */
     // @unsafe - mutates linked list pointers without borrow tracking
-    static void link_split(N &n, N &nr) {
+    static void link_split(N *n, N *nr) {
         link_split(n, nr, relax_fence_function());
     }
     /** @overload */
     template <typename SF>
     // @unsafe - raw pointer rewiring with CAS operations
-    static void link_split(N &n, N &nr, SF spin_function) {
-        nr.prev_ = &n;
+    static void link_split(N *n, N *nr, SF spin_function) {
+        nr->prev_ = n;
         N *next = lock_next(n, spin_function);
-        nr.next_.ptr = next;
+        nr->next_.ptr = next;
         if (next)
-            next->prev_ = &nr;
+            next->prev_ = nr;
         fence();
-        n.next_.ptr = &nr;
+        n->next_.ptr = nr;
     }
 
     /** @brief Unlink @a n from the list.
@@ -83,20 +83,20 @@ template <typename N> struct btree_leaflink<N, true> {
         Concurrency correctness: Works even in the presence of concurrent
         splits and deletes. */
     // @unsafe - rewires prev/next pointers of raw leaves
-    static void unlink(N &n) {
+    static void unlink(N *n) {
         unlink(n, relax_fence_function());
     }
     /** @overload */
     template <typename SF>
     // @unsafe - raw unlink operation with CAS
-    static void unlink(N &n, SF spin_function) {
+    static void unlink(N *n, SF spin_function) {
         // Assume node order A <-> N <-> B. Since n is locked, n cannot split;
         // next node will always be B or one of its successors.
         N *next = lock_next(n, spin_function);
         N *prev;
         while (1) {
-            prev = n.prev_;
-            if (bool_cmpxchg(&prev->next_.ptr, &n, mark(&n)))
+            prev = n->prev_;
+            if (bool_cmpxchg(&prev->next_.ptr, n, mark(n)))
                 break;
             spin_function();
         }
@@ -110,29 +110,29 @@ template <typename N> struct btree_leaflink<N, true> {
 
 // This is the single-threaded-only fast version of btree_leaflink.
 template <typename N> struct btree_leaflink<N, false> {
-    // @unsafe - address-of operations on references for linked list pointers
-    static void link_split(N &n, N &nr) {
+    // @unsafe - raw pointer operations for linked list management
+    static void link_split(N *n, N *nr) {
         link_split(n, nr, do_nothing());
     }
     template <typename SF>
-    // @unsafe - address-of operations on references for linked list pointers
-    static void link_split(N &n, N &nr, SF) {
-        nr.prev_ = &n;
-        nr.next_.ptr = n.next_.ptr;
-        n.next_.ptr = &nr;
-        if (nr.next_.ptr)
-            nr.next_.ptr->prev_ = &nr;
+    // @unsafe - raw pointer operations for linked list management
+    static void link_split(N *n, N *nr, SF) {
+        nr->prev_ = n;
+        nr->next_.ptr = n->next_.ptr;
+        n->next_.ptr = nr;
+        if (nr->next_.ptr)
+            nr->next_.ptr->prev_ = nr;
     }
-    // @unsafe - delegates to unsafe unlink with spin function
-    static void unlink(N &n) {
+    // @unsafe - raw pointer operations for linked list management
+    static void unlink(N *n) {
         unlink(n, do_nothing());
     }
     template <typename SF>
-    // @unsafe - raw pointer dereferences for linked list traversal
-    static void unlink(N &n, SF) {
-        if (n.next_.ptr)
-            n.next_.ptr->prev_ = n.prev_;
-        n.prev_->next_.ptr = n.next_.ptr;
+    // @unsafe - raw pointer operations for linked list management
+    static void unlink(N *n, SF) {
+        if (n->next_.ptr)
+            n->next_.ptr->prev_ = n->prev_;
+        n->prev_->next_.ptr = n->next_.ptr;
     }
 };
 

--- a/src/mako/masstree/checkpoint.cc
+++ b/src/mako/masstree/checkpoint.cc
@@ -15,6 +15,9 @@
  */
 // Checkpoint serialization for Masstree data persistence
 //
+// @external: {
+//   threadinfo: [unsafe_type]
+// }
 // @external_unsafe_type: std::*
 // @external_unsafe: std::*
 // @external_unsafe: circular_int::*

--- a/src/mako/masstree/checkpoint.cc
+++ b/src/mako/masstree/checkpoint.cc
@@ -17,10 +17,12 @@
 //
 // @external: {
 //   threadinfo: [unsafe_type]
+//   lcdf::String: [unsafe_type]
+//   circular_int: [unsafe_type]
 // }
 // @external_unsafe_type: std::*
+// @external_unsafe_type: circular_int
 // @external_unsafe: std::*
-// @external_unsafe: circular_int::*
 // @external_unsafe: lcdf::String_base::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: lcdf::String_generic::*
@@ -36,7 +38,7 @@
 bool ckstate::visit_value(Str key, const row_type* value, threadinfo&) {
     if (endkey && key >= endkey)
         return false;
-    if (!row_is_marker(value)) {
+    if (!row_is_marker(*value)) {
         msgpack::unparser<kvout> up(*vals);
         up.write(key).write_wide(value->timestamp());
         value->checkpoint_write(up);

--- a/src/mako/masstree/checkpoint.cc
+++ b/src/mako/masstree/checkpoint.cc
@@ -1,3 +1,6 @@
+// @unsafe - Checkpoint serialization for Masstree data persistence
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2013 President and Fellows of Harvard College
@@ -13,8 +16,6 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// Checkpoint serialization for Masstree data persistence
-//
 // @external: {
 //   threadinfo: [unsafe_type]
 //   lcdf::String: [unsafe_type]
@@ -25,7 +26,6 @@
 // }
 // @external_unsafe_type: std::*
 // @external_unsafe_type: circular_int
-// @external_unsafe: std::*
 // @external_unsafe: lcdf::String_base::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: lcdf::String_generic::*

--- a/src/mako/masstree/checkpoint.cc
+++ b/src/mako/masstree/checkpoint.cc
@@ -19,6 +19,9 @@
 //   threadinfo: [unsafe_type]
 //   lcdf::String: [unsafe_type]
 //   circular_int: [unsafe_type]
+//   MasstreeContext::get_epoch: [unsafe]
+//   __builtin_expect: [unsafe]
+//   timestamp: [unsafe]
 // }
 // @external_unsafe_type: std::*
 // @external_unsafe_type: circular_int

--- a/src/mako/masstree/checkpoint.hh
+++ b/src/mako/masstree/checkpoint.hh
@@ -33,6 +33,7 @@ struct ckstate {
     Str startkey;
     Str endkey;
 
+    // @safe - empty visitor function, no operations
     template <typename SS, typename K>
     void visit_leaf(const SS&, const K&, threadinfo&) {
     }

--- a/src/mako/masstree/checkpoint.hh
+++ b/src/mako/masstree/checkpoint.hh
@@ -16,6 +16,7 @@
 // @unsafe - Checkpoint state and visitor pattern for tree serialization
 // Defines ckstate for collecting key-value pairs during checkpoint
 // SAFETY: Uses kvout buffers and msgpack serialization
+// @external: { htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe], threadinfo::pthread: [unsafe] }
 
 #ifndef MASSTREE_CHECKPOINT_HH
 #define MASSTREE_CHECKPOINT_HH

--- a/src/mako/masstree/circular_int.hh
+++ b/src/mako/masstree/circular_int.hh
@@ -42,48 +42,42 @@ class circular_int {
         return v_;
     }
 
-    // @unsafe - returns mutable reference to this
-    // @lifetime: (&'a mut) -> &'a mut
+    // @unsafe - @lifetime: (&'a mut) -> &'a mut (prefix returns reference)
     circular_int<T> &operator++() {
         ++v_;
         return *this;
     }
-    // @unsafe - postfix returns value but checker conflates with prefix
+    // @unsafe - postfix returns value copy but marked unsafe to avoid annotation collision
     circular_int<T> operator++(int) {
         ++v_;
         return circular_int<T>(v_ - 1);
     }
-    // @unsafe - returns mutable reference to this
-    // @lifetime: (&'a mut) -> &'a mut
+    // @unsafe - @lifetime: (&'a mut) -> &'a mut (prefix returns reference)
     circular_int<T> &operator--() {
         --v_;
         return *this;
     }
-    // @unsafe - postfix returns value but checker conflates with prefix
+    // @unsafe - postfix returns value copy but marked unsafe to avoid annotation collision
     circular_int<T> operator--(int) {
         --v_;
         return circular_int<T>(v_ + 1);
     }
-    // @unsafe
-    // @lifetime: (&'a mut, unsigned) -> &'a mut
+    // @unsafe - returns mutable reference; @lifetime: (&'a mut, unsigned) -> &'a mut
     circular_int<T> &operator+=(unsigned x) {
         v_ += x;
         return *this;
     }
-    // @unsafe
-    // @lifetime: (&'a mut, int) -> &'a mut
+    // @unsafe - returns mutable reference; @lifetime: (&'a mut, int) -> &'a mut
     circular_int<T> &operator+=(int x) {
         v_ += x;
         return *this;
     }
-    // @unsafe
-    // @lifetime: (&'a mut, unsigned) -> &'a mut
+    // @unsafe - returns mutable reference; @lifetime: (&'a mut, unsigned) -> &'a mut
     circular_int<T> &operator-=(unsigned x) {
         v_ -= x;
         return *this;
     }
-    // @unsafe
-    // @lifetime: (&'a mut, int) -> &'a mut
+    // @unsafe - returns mutable reference; @lifetime: (&'a mut, int) -> &'a mut
     circular_int<T> &operator-=(int x) {
         v_ -= x;
         return *this;
@@ -116,12 +110,12 @@ class circular_int {
     circular_int<T> operator+(int x) const {
         return circular_int<T>(v_ + x);
     }
-    // @unsafe - checker interprets !v as address-of operation
+    // @unsafe - checker false positive: interprets !v as address-of instead of logical NOT
     circular_int<T> next_nonzero() const {
         value_type v = v_ + 1;
         return circular_int<T>(v + !v);
     }
-    // @unsafe - checker interprets !x as address-of operation
+    // @unsafe - checker false positive: interprets !x as address-of instead of logical NOT
     static value_type next_nonzero(value_type x) {
         ++x;
         return x + !x;

--- a/src/mako/masstree/circular_int.hh
+++ b/src/mako/masstree/circular_int.hh
@@ -110,12 +110,12 @@ class circular_int {
     circular_int<T> operator+(int x) const {
         return circular_int<T>(v_ + x);
     }
-    // @unsafe - checker false positive: interprets !v as address-of instead of logical NOT
+    // @safe - pure arithmetic (skip zero: if v==0, !v==1, so result is 1)
     circular_int<T> next_nonzero() const {
         value_type v = v_ + 1;
         return circular_int<T>(v + !v);
     }
-    // @unsafe - checker false positive: interprets !x as address-of instead of logical NOT
+    // @safe - pure arithmetic (skip zero: if x==0, !x==1, so result is 1)
     static value_type next_nonzero(value_type x) {
         ++x;
         return x + !x;

--- a/src/mako/masstree/circular_int.hh
+++ b/src/mako/masstree/circular_int.hh
@@ -42,22 +42,24 @@ class circular_int {
         return v_;
     }
 
-    // @unsafe
+    // @unsafe - returns mutable reference to this
     // @lifetime: (&'a mut) -> &'a mut
     circular_int<T> &operator++() {
         ++v_;
         return *this;
     }
+    // @unsafe - postfix returns value but checker conflates with prefix
     circular_int<T> operator++(int) {
         ++v_;
         return circular_int<T>(v_ - 1);
     }
-    // @unsafe
+    // @unsafe - returns mutable reference to this
     // @lifetime: (&'a mut) -> &'a mut
     circular_int<T> &operator--() {
         --v_;
         return *this;
     }
+    // @unsafe - postfix returns value but checker conflates with prefix
     circular_int<T> operator--(int) {
         --v_;
         return circular_int<T>(v_ + 1);
@@ -114,12 +116,12 @@ class circular_int {
     circular_int<T> operator+(int x) const {
         return circular_int<T>(v_ + x);
     }
-    // @unsafe - uses logical NOT that checker interprets as address-of
+    // @unsafe - checker interprets !v as address-of operation
     circular_int<T> next_nonzero() const {
         value_type v = v_ + 1;
         return circular_int<T>(v + !v);
     }
-    // @unsafe - uses logical NOT that checker interprets as address-of
+    // @unsafe - checker interprets !x as address-of operation
     static value_type next_nonzero(value_type x) {
         ++x;
         return x + !x;

--- a/src/mako/masstree/circular_int.hh
+++ b/src/mako/masstree/circular_int.hh
@@ -42,7 +42,8 @@ class circular_int {
         return v_;
     }
 
-    // @unsafe - @lifetime: (&'a mut) -> &'a mut (prefix returns reference)
+    // @unsafe - prefix returns reference
+    // @lifetime: (&'a mut) -> &'a mut
     circular_int<T> &operator++() {
         ++v_;
         return *this;
@@ -52,7 +53,8 @@ class circular_int {
         ++v_;
         return circular_int<T>(v_ - 1);
     }
-    // @unsafe - @lifetime: (&'a mut) -> &'a mut (prefix returns reference)
+    // @unsafe - prefix returns reference
+    // @lifetime: (&'a mut) -> &'a mut
     circular_int<T> &operator--() {
         --v_;
         return *this;
@@ -62,22 +64,26 @@ class circular_int {
         --v_;
         return circular_int<T>(v_ + 1);
     }
-    // @unsafe - returns mutable reference; @lifetime: (&'a mut, unsigned) -> &'a mut
+    // @unsafe - returns mutable reference
+    // @lifetime: (&'a mut, unsigned) -> &'a mut
     circular_int<T> &operator+=(unsigned x) {
         v_ += x;
         return *this;
     }
-    // @unsafe - returns mutable reference; @lifetime: (&'a mut, int) -> &'a mut
+    // @unsafe - returns mutable reference
+    // @lifetime: (&'a mut, int) -> &'a mut
     circular_int<T> &operator+=(int x) {
         v_ += x;
         return *this;
     }
-    // @unsafe - returns mutable reference; @lifetime: (&'a mut, unsigned) -> &'a mut
+    // @unsafe - returns mutable reference
+    // @lifetime: (&'a mut, unsigned) -> &'a mut
     circular_int<T> &operator-=(unsigned x) {
         v_ -= x;
         return *this;
     }
-    // @unsafe - returns mutable reference; @lifetime: (&'a mut, int) -> &'a mut
+    // @unsafe - returns mutable reference
+    // @lifetime: (&'a mut, int) -> &'a mut
     circular_int<T> &operator-=(int x) {
         v_ -= x;
         return *this;

--- a/src/mako/masstree/compiler.hh
+++ b/src/mako/masstree/compiler.hh
@@ -125,12 +125,16 @@ inline void memory_fence() {
 }
 
 /** @brief Do-nothing function object. */
+// @safe - all methods are pure no-ops
 struct do_nothing {
+    // @safe - no-op
     void operator()() const {
     }
+    // @safe - no-op
     template <typename T>
     void operator()(const T&) const {
     }
+    // @safe - no-op
     template <typename T, typename U>
     void operator()(const T&, const U&) const {
     }
@@ -752,79 +756,95 @@ inline int find_lowest_zero_nibble(T x) {
     return t ? ctz(t) >> 2 : -1;
 }
 
-// @unsafe - calls system byte-order functions (htons, htonl, htonq) which are external unsafe
 // SAFETY: These are pure byte-order conversion functions with no side effects
+// Note: char versions are @safe (identity), larger types use external htons/htonl/htonq
 /** @brief Translate @a x to network byte order.
  *
  * Compare htons/htonl/htonq.  host_to_net_order is particularly useful in
  * template functions, where the type to be translated to network byte order
  * is unknown. */
+// @safe - identity function
 inline unsigned char host_to_net_order(unsigned char x) {
     return x;
 }
+// @safe - identity function
 /** @overload */
 inline signed char host_to_net_order(signed char x) {
     return x;
 }
+// @safe - identity function
 /** @overload */
 inline char host_to_net_order(char x) {
     return x;
 }
+// @safe - pure byte swapping
 /** @overload */
 inline short host_to_net_order(short x) {
     return htons(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline unsigned short host_to_net_order(unsigned short x) {
     return htons(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline int host_to_net_order(int x) {
     return htonl(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline unsigned host_to_net_order(unsigned x) {
     return htonl(x);
 }
 #if SIZEOF_LONG == 4
+// @safe - pure byte swapping
 /** @overload */
 inline long host_to_net_order(long x) {
     return htonl(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline unsigned long host_to_net_order(unsigned long x) {
     return htonl(x);
 }
 #elif SIZEOF_LONG == 8
+// @safe - pure byte swapping
 /** @overload */
 inline long host_to_net_order(long x) {
     return htonq(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline unsigned long host_to_net_order(unsigned long x) {
     return htonq(x);
 }
 #endif
 #if SIZEOF_LONG_LONG == 8
+// @safe - pure byte swapping
 /** @overload */
 inline long long host_to_net_order(long long x) {
     return htonq(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline unsigned long long host_to_net_order(unsigned long long x) {
     return htonq(x);
 }
 #endif
 #if !HAVE_INT64_T_IS_LONG && !HAVE_INT64_T_IS_LONG_LONG
+// @safe - pure byte swapping
 /** @overload */
 inline int64_t host_to_net_order(int64_t x) {
     return htonq(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline uint64_t host_to_net_order(uint64_t x) {
     return htonq(x);
 }
 #endif
+// @safe - pure byte swapping via union
 /** @overload */
 inline double host_to_net_order(float x) {
     union { float f; uint32_t i; } v;
@@ -832,6 +852,7 @@ inline double host_to_net_order(float x) {
     v.i = host_to_net_order(v.i);
     return v.f;
 }
+// @safe - pure byte swapping via union
 /** @overload */
 inline double host_to_net_order(double x) {
     union { double d; uint64_t i; } v;
@@ -845,76 +866,93 @@ inline double host_to_net_order(double x) {
  * Compare ntohs/ntohl/ntohq.  net_to_host_order is particularly useful in
  * template functions, where the type to be translated to network byte order
  * is unknown. */
+// @safe - identity function
 inline unsigned char net_to_host_order(unsigned char x) {
     return x;
 }
+// @safe - identity function
 /** @overload */
 inline signed char net_to_host_order(signed char x) {
     return x;
 }
+// @safe - identity function
 /** @overload */
 inline char net_to_host_order(char x) {
     return x;
 }
+// @safe - pure byte swapping
 /** @overload */
 inline short net_to_host_order(short x) {
     return ntohs(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline unsigned short net_to_host_order(unsigned short x) {
     return ntohs(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline int net_to_host_order(int x) {
     return ntohl(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline unsigned net_to_host_order(unsigned x) {
     return ntohl(x);
 }
 #if SIZEOF_LONG == 4
+// @safe - pure byte swapping
 /** @overload */
 inline long net_to_host_order(long x) {
     return ntohl(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline unsigned long net_to_host_order(unsigned long x) {
     return ntohl(x);
 }
 #elif SIZEOF_LONG == 8
+// @safe - pure byte swapping
 /** @overload */
 inline long net_to_host_order(long x) {
     return ntohq(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline unsigned long net_to_host_order(unsigned long x) {
     return ntohq(x);
 }
 #endif
 #if SIZEOF_LONG_LONG == 8
+// @safe - pure byte swapping
 /** @overload */
 inline long long net_to_host_order(long long x) {
     return ntohq(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline unsigned long long net_to_host_order(unsigned long long x) {
     return ntohq(x);
 }
 #endif
 #if !HAVE_INT64_T_IS_LONG && !HAVE_INT64_T_IS_LONG_LONG
+// @safe - pure byte swapping
 /** @overload */
 inline int64_t net_to_host_order(int64_t x) {
     return ntohq(x);
 }
+// @safe - pure byte swapping
 /** @overload */
 inline uint64_t net_to_host_order(uint64_t x) {
     return ntohq(x);
 }
 #endif
+// @safe - delegates to safe host_to_net_order
 /** @overload */
 inline double net_to_host_order(float x) {
     return host_to_net_order(x);
 }
+// @safe - delegates to safe host_to_net_order
 /** @overload */
 inline double net_to_host_order(double x) {
     return host_to_net_order(x);

--- a/src/mako/masstree/compiler.hh
+++ b/src/mako/masstree/compiler.hh
@@ -93,16 +93,19 @@ inline int ffs_msb(unsigned long long x) {
  *
  * Prevents reordering of loads and stores by the compiler. Not intended to
  * synchronize the processor's caches. */
+// @unsafe - uses inline assembly for memory barrier
 inline void fence() {
     asm volatile("" : : : "memory");
 }
 
 /** @brief Acquire fence. */
+// @unsafe - uses inline assembly for memory barrier
 inline void acquire_fence() {
     asm volatile("" : : : "memory");
 }
 
 /** @brief Release fence. */
+// @unsafe - uses inline assembly for memory barrier
 inline void release_fence() {
     asm volatile("" : : : "memory");
 }
@@ -110,11 +113,13 @@ inline void release_fence() {
 /** @brief Compiler fence that relaxes the processor.
 
     Use this in spinloops, for example. */
+// @unsafe - uses inline assembly for CPU pause and memory barrier
 inline void relax_fence() {
     asm volatile("pause" : : : "memory"); // equivalent to "rep; nop"
 }
 
 /** @brief Full memory fence. */
+// @unsafe - uses inline assembly for full memory fence
 inline void memory_fence() {
     asm volatile("mfence" : : : "memory");
 }
@@ -132,24 +137,31 @@ struct do_nothing {
 };
 
 /** @brief Function object that calls fence(). */
+// @safe - functor that calls @unsafe fence(); @safe can call @unsafe
 struct fence_function {
+    // @safe - calls @unsafe fence()
     void operator()() const {
         fence();
     }
 };
 
 /** @brief Function object that calls relax_fence(). */
+// @safe - functor that calls @unsafe relax_fence(); @safe can call @unsafe
 struct relax_fence_function {
+    // @safe - calls @unsafe relax_fence()
     void operator()() const {
         relax_fence();
     }
 };
 
 /** @brief Function object that calls relax_fence() with backoff. */
+// @safe - functor that calls @unsafe relax_fence(); @safe can call @unsafe
 struct backoff_fence_function {
+    // @safe - default construction
     backoff_fence_function()
         : count_(0) {
     }
+    // @safe - calls @unsafe relax_fence() in loop
     void operator()() {
         for (int i = count_; i >= 0; --i)
             relax_fence();

--- a/src/mako/masstree/compiler.hh
+++ b/src/mako/masstree/compiler.hh
@@ -73,14 +73,16 @@
  * @return 0 if @a x = 0; otherwise the index of first bit set, where the
  * most significant bit is numbered 1.
  */
-// @unsafe - bit-twiddling helpers with raw intrinsics
+// @safe - pure bit-counting compiler intrinsics
 inline int ffs_msb(unsigned x) {
     return (x ? __builtin_clz(x) + 1 : 0);
 }
+// @safe - pure bit-counting compiler intrinsic
 /** @overload */
 inline int ffs_msb(unsigned long x) {
     return (x ? __builtin_clzl(x) + 1 : 0);
 }
+// @safe - pure bit-counting compiler intrinsic
 /** @overload */
 inline int ffs_msb(unsigned long long x) {
     return (x ? __builtin_clzll(x) + 1 : 0);
@@ -631,6 +633,8 @@ inline uint64_t htonq(uint64_t val) {
 
 /** Bit counting. */
 
+// @unsafe - calls compiler intrinsics which are considered external unsafe functions
+// SAFETY: These are pure bit-counting operations with no side effects
 /** @brief Return the number of leading 0 bits in @a x.
  * @pre @a x != 0
  *
@@ -662,6 +666,8 @@ inline int clz(unsigned long long x) {
 }
 #endif
 
+// @unsafe - calls compiler intrinsics which are considered external unsafe functions
+// SAFETY: These are pure bit-counting operations with no side effects
 /** @brief Return the number of trailing 0 bits in @a x.
  * @pre @a x != 0
  *
@@ -693,12 +699,14 @@ inline int ctz(unsigned long long x) {
 }
 #endif
 
+// @safe - pure integer arithmetic
 template <typename T, typename U>
 inline T iceil(T x, U y) {
     U mod = x % y;
     return x + (mod ? y - mod : 0);
 }
 
+// @unsafe - calls clz() which is unsafe
 /** @brief Return the smallest power of 2 greater than or equal to @a x.
     @pre @a x != 0
     @pre the result is representable in type T (that is, @a x can't be
@@ -708,6 +716,7 @@ inline T iceil_log2(T x) {
     return T(1) << (sizeof(T) * 8 - clz(x) - !(x & (x - 1)));
 }
 
+// @unsafe - calls clz() which is unsafe
 /** @brief Return the largest power of 2 less than or equal to @a x.
     @pre @a x != 0 */
 template <typename T>
@@ -715,6 +724,7 @@ inline T ifloor_log2(T x) {
     return T(1) << (sizeof(T) * 8 - 1 - clz(x));
 }
 
+// @unsafe - calls ctz() which is unsafe
 /** @brief Return the index of the lowest 0 nibble in @a x.
  *
  * 0 is the lowest-order nibble. Returns -1 if no nibbles are 0. */
@@ -730,6 +740,8 @@ inline int find_lowest_zero_nibble(T x) {
     return t ? ctz(t) >> 2 : -1;
 }
 
+// @unsafe - calls system byte-order functions (htons, htonl, htonq) which are external unsafe
+// SAFETY: These are pure byte-order conversion functions with no side effects
 /** @brief Translate @a x to network byte order.
  *
  * Compare htons/htonl/htonq.  host_to_net_order is particularly useful in
@@ -980,7 +992,7 @@ inline uint64_t read_tsc(void)
     return ((uint64_t)low) | (((uint64_t)high) << 32);
 }
 
-// @unsafe
+// @safe - pure comparison of values
 template <typename T>
 inline int compare(T a, T b) {
     if (a == b)

--- a/src/mako/masstree/compiler.hh
+++ b/src/mako/masstree/compiler.hh
@@ -179,6 +179,7 @@ struct backoff_fence_function {
 
 template <int SIZE, typename BARRIER> struct sized_compiler_operations;
 
+// @unsafe - atomic operations using inline assembly for 1-byte values
 template <typename B> struct sized_compiler_operations<1, B> {
     typedef char type;
     static inline type xchg(type* object, type new_value) {
@@ -231,6 +232,7 @@ template <typename B> struct sized_compiler_operations<1, B> {
     }
 };
 
+// @unsafe - atomic operations using inline assembly for 2-byte values
 template <typename B> struct sized_compiler_operations<2, B> {
 #if SIZEOF_SHORT == 2
     typedef short type;
@@ -287,6 +289,7 @@ template <typename B> struct sized_compiler_operations<2, B> {
     }
 };
 
+// @unsafe - atomic operations using inline assembly for 4-byte values
 template <typename B> struct sized_compiler_operations<4, B> {
 #if SIZEOF_INT == 4
     typedef int type;
@@ -343,6 +346,7 @@ template <typename B> struct sized_compiler_operations<4, B> {
     }
 };
 
+// @unsafe - atomic operations using inline assembly for 8-byte values
 template <typename B> struct sized_compiler_operations<8, B> {
 #if SIZEOF_LONG_LONG == 8
     typedef long long type;
@@ -425,6 +429,7 @@ template <typename B> struct sized_compiler_operations<8, B> {
 #endif
 };
 
+// @unsafe - atomic exchange using inline assembly
 template<typename T>
 inline T xchg(T* object, T new_value) {
     typedef sized_compiler_operations<sizeof(T), fence_function> sco_t;
@@ -432,18 +437,23 @@ inline T xchg(T* object, T new_value) {
     return (T) sco_t::xchg((type*) object, (type) new_value);
 }
 
+// @unsafe - atomic exchange overloads
 inline int8_t xchg(int8_t* object, int new_value) {
     return xchg(object, (int8_t) new_value);
 }
+// @unsafe - atomic exchange overload
 inline uint8_t xchg(uint8_t* object, int new_value) {
     return xchg(object, (uint8_t) new_value);
 }
+// @unsafe - atomic exchange overload
 inline int16_t xchg(int16_t* object, int new_value) {
     return xchg(object, (int16_t) new_value);
 }
+// @unsafe - atomic exchange overload
 inline uint16_t xchg(uint16_t* object, int new_value) {
     return xchg(object, (uint16_t) new_value);
 }
+// @unsafe - atomic exchange overload
 inline unsigned xchg(unsigned* object, int new_value) {
     return xchg(object, (unsigned) new_value);
 }
@@ -461,6 +471,7 @@ inline unsigned xchg(unsigned* object, int new_value) {
  *    *object = desired;
  * return actual;
  * @endcode */
+// @unsafe - atomic compare-and-exchange using inline assembly
 template <typename T>
 inline T cmpxchg(T* object, T expected, T desired) {
     typedef sized_compiler_operations<sizeof(T), fence_function> sco_t;
@@ -468,6 +479,7 @@ inline T cmpxchg(T* object, T expected, T desired) {
     return (T) sco_t::val_cmpxchg((type*) object, (type) expected, (type) desired);
 }
 
+// @unsafe - atomic compare-and-exchange overload
 inline unsigned cmpxchg(unsigned *object, int expected, int desired) {
     return cmpxchg(object, unsigned(expected), unsigned(desired));
 }
@@ -487,6 +499,7 @@ inline unsigned cmpxchg(unsigned *object, int expected, int desired) {
  * } else
  *    return false;
  * @endcode */
+// @unsafe - atomic boolean compare-and-exchange using inline assembly
 template <typename T>
 inline bool bool_cmpxchg(T* object, T expected, T desired) {
     typedef sized_compiler_operations<sizeof(T), fence_function> sco_t;
@@ -494,9 +507,11 @@ inline bool bool_cmpxchg(T* object, T expected, T desired) {
     return sco_t::bool_cmpxchg((type*) object, (type) expected, (type) desired);
 }
 
+// @unsafe - atomic boolean compare-and-exchange overload
 inline bool bool_cmpxchg(uint8_t* object, int expected, int desired) {
     return bool_cmpxchg(object, uint8_t(expected), uint8_t(desired));
 }
+// @unsafe - atomic boolean compare-and-exchange overload
 inline bool bool_cmpxchg(unsigned *object, int expected, int desired) {
     return bool_cmpxchg(object, unsigned(expected), unsigned(desired));
 }
@@ -505,6 +520,7 @@ inline bool bool_cmpxchg(unsigned *object, int expected, int desired) {
  * @param object pointer to integer
  * @param addend value to add
  * @return old value */
+// @unsafe - atomic fetch-and-add using inline assembly
 template <typename T>
 inline T fetch_and_add(T* object, T addend) {
     typedef sized_compiler_operations<sizeof(T), fence_function> sco_t;
@@ -512,6 +528,7 @@ inline T fetch_and_add(T* object, T addend) {
     return (T) sco_t::fetch_and_add((type*) object, (type) addend);
 }
 
+// @unsafe - atomic fetch-and-add pointer overload
 template <typename T>
 inline T* fetch_and_add(T** object, int addend) {
     typedef sized_compiler_operations<sizeof(T*), fence_function> sco_t;
@@ -519,27 +536,34 @@ inline T* fetch_and_add(T** object, int addend) {
     return (T*) sco_t::fetch_and_add((type*) object, (type) (addend * sizeof(T)));
 }
 
+// @unsafe - atomic fetch-and-add overload
 inline int8_t fetch_and_add(int8_t* object, int addend) {
     return fetch_and_add(object, int8_t(addend));
 }
+// @unsafe - atomic fetch-and-add overload
 inline uint8_t fetch_and_add(uint8_t* object, int addend) {
     return fetch_and_add(object, uint8_t(addend));
 }
+// @unsafe - atomic fetch-and-add overload
 inline int16_t fetch_and_add(int16_t* object, int addend) {
     return fetch_and_add(object, int16_t(addend));
 }
+// @unsafe - atomic fetch-and-add overload
 inline uint16_t fetch_and_add(uint16_t* object, int addend) {
     return fetch_and_add(object, uint16_t(addend));
 }
+// @unsafe - atomic fetch-and-add overload
 inline unsigned fetch_and_add(unsigned* object, int addend) {
     return fetch_and_add(object, unsigned(addend));
 }
+// @unsafe - atomic fetch-and-add overload
 inline unsigned long fetch_and_add(unsigned long* object, int addend) {
     return fetch_and_add(object, (unsigned long)(addend));
 }
 
 
 /** @brief Test-and-set lock acquire. */
+// @unsafe - uses atomic xchg in spin loop
 template <typename T>
 inline void test_and_set_acquire(T* object) {
     typedef sized_compiler_operations<sizeof(T), do_nothing> sco_t;
@@ -550,6 +574,7 @@ inline void test_and_set_acquire(T* object) {
 }
 
 /** @brief Test-and-set lock release. */
+// @unsafe - uses release fence and raw pointer write
 template <typename T>
 inline void test_and_set_release(T* object) {
     release_fence();
@@ -560,6 +585,7 @@ inline void test_and_set_release(T* object) {
 /** @brief Atomic fetch-and-or. Returns nothing.
  * @param object pointer to integer
  * @param addend value to or */
+// @unsafe - atomic fetch-and-or using inline assembly
 template <typename T>
 inline void atomic_or(T* object, T addend) {
     typedef sized_compiler_operations<sizeof(T), fence_function> sco_t;
@@ -567,21 +593,27 @@ inline void atomic_or(T* object, T addend) {
     sco_t::atomic_or((type*) object, (type) addend);
 }
 
+// @unsafe - atomic fetch-and-or overload
 inline void atomic_or(int8_t* object, int addend) {
     atomic_or(object, int8_t(addend));
 }
+// @unsafe - atomic fetch-and-or overload
 inline void atomic_or(uint8_t* object, int addend) {
     atomic_or(object, uint8_t(addend));
 }
+// @unsafe - atomic fetch-and-or overload
 inline void atomic_or(int16_t* object, int addend) {
     atomic_or(object, int16_t(addend));
 }
+// @unsafe - atomic fetch-and-or overload
 inline void atomic_or(uint16_t* object, int addend) {
     atomic_or(object, uint16_t(addend));
 }
+// @unsafe - atomic fetch-and-or overload
 inline void atomic_or(unsigned* object, int addend) {
     atomic_or(object, unsigned(addend));
 }
+// @unsafe - atomic fetch-and-or overload
 inline void atomic_or(unsigned long* object, int addend) {
     atomic_or(object, (unsigned long)(addend));
 }

--- a/src/mako/masstree/compiler.hh
+++ b/src/mako/masstree/compiler.hh
@@ -16,6 +16,7 @@
 // Compiler intrinsics, memory fences, and type traits
 // Provides portable wrappers for atomic operations and compiler hints
 // SAFETY: Contains memory barriers, likely/unlikely macros, type manipulation
+// @external: { htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe], __builtin_expect: [unsafe] }
 
 #ifndef MASSTREE_COMPILER_HH
 #define MASSTREE_COMPILER_HH 1

--- a/src/mako/masstree/file.cc
+++ b/src/mako/masstree/file.cc
@@ -16,6 +16,12 @@
 // File I/O utilities using raw file descriptors
 // All functions are @unsafe - use POSIX file operations
 //
+// SAFETY NOTE: These functions cannot be made safe because:
+// 1. They use POSIX syscalls (open, read, write, close, fsync, rename)
+// 2. They manipulate raw file descriptors (int) which have no ownership semantics
+// 3. They use raw char* buffers from StringAccum for I/O
+// 4. Error handling requires checking errno global variable
+//
 // @external_unsafe_type: std::*
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*

--- a/src/mako/masstree/file.cc
+++ b/src/mako/masstree/file.cc
@@ -1,3 +1,5 @@
+// @unsafe - File I/O utilities using raw file descriptors
+// @external_unsafe: std::*
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2014 President and Fellows of Harvard College
@@ -13,7 +15,6 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// File I/O utilities using raw file descriptors
 // All functions are @unsafe - use POSIX file operations
 //
 // SAFETY NOTE: These functions cannot be made safe because:
@@ -32,6 +33,7 @@
 // @external_unsafe: fsync
 // @external_unsafe: rename
 // @external_unsafe: safe_write
+// @external_unsafe: hashcode
 
 #include "file.hh"
 #include "straccum.hh"

--- a/src/mako/masstree/file.hh
+++ b/src/mako/masstree/file.hh
@@ -16,6 +16,7 @@
 // @unsafe - File utility functions for reading file contents
 // Provides read_file_contents for loading files into lcdf::String
 // SAFETY: Uses POSIX file descriptors and system calls
+// @external: { lcdf::String: [unsafe_type], String: [unsafe_type], assign: [unsafe] }
 
 #ifndef KVDB_FILE_HH
 #define KVDB_FILE_HH 1

--- a/src/mako/masstree/file.hh
+++ b/src/mako/masstree/file.hh
@@ -16,7 +16,7 @@
 // @unsafe - File utility functions for reading file contents
 // Provides read_file_contents for loading files into lcdf::String
 // SAFETY: Uses POSIX file descriptors and system calls
-// @external: { lcdf::String: [unsafe_type], String: [unsafe_type], assign: [unsafe] }
+// @external: { lcdf::String: [unsafe_type], String: [unsafe_type], assign: [unsafe], htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe], hashcode: [unsafe] }
 
 #ifndef KVDB_FILE_HH
 #define KVDB_FILE_HH 1

--- a/src/mako/masstree/hashcode.hh
+++ b/src/mako/masstree/hashcode.hh
@@ -13,9 +13,9 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe - Hash code computation for various types
+// @safe - Hash code computation for various types
 // Provides hashcode<T> templates compatible with std::hash
-// SAFETY: Pure computation, no memory operations
+// Pure computation, no memory operations (except pointer hash)
 
 #ifndef CLICK_HASHCODE_HH
 #define CLICK_HASHCODE_HH
@@ -39,7 +39,7 @@
 typedef size_t hashcode_t;	///< Typical type for a hashcode() value.
 
 template <typename T>
-// @unsafe - raw hash helpers without lifetime tracking
+// @safe - delegates to T::hashcode() which is pure computation
 inline hashcode_t hashcode(T const &x) {
     return x.hashcode();
 }

--- a/src/mako/masstree/hashcode.hh
+++ b/src/mako/masstree/hashcode.hh
@@ -1,3 +1,7 @@
+// @unsafe - Hash code computation using casts and pointer operations
+// @external_unsafe: std::*
+// Provides hashcode<T> templates compatible with std::hash
+// Uses C-style casts and reinterpret_cast for pointer hashing
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2013 President and Fellows of Harvard College
@@ -13,9 +17,6 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @safe - Hash code computation for various types
-// Provides hashcode<T> templates compatible with std::hash
-// Pure computation, no memory operations (except pointer hash)
 
 #ifndef CLICK_HASHCODE_HH
 #define CLICK_HASHCODE_HH
@@ -39,7 +40,7 @@
 typedef size_t hashcode_t;	///< Typical type for a hashcode() value.
 
 template <typename T>
-// @safe - delegates to T::hashcode() which is pure computation
+// @unsafe - cannot verify T::hashcode() is safe at compile time
 inline hashcode_t hashcode(T const &x) {
     return x.hashcode();
 }
@@ -124,8 +125,8 @@ inline hashcode_t hashcode(uint64_t const &x) {
 }
 #endif
 
-template <typename T>
 // @unsafe - hashes raw pointer bits
+template <typename T>
 inline hashcode_t hashcode(T * const &x) {
     return reinterpret_cast<uintptr_t>(x) >> 3;
 }

--- a/src/mako/masstree/hashcode.hh
+++ b/src/mako/masstree/hashcode.hh
@@ -44,67 +44,80 @@ inline hashcode_t hashcode(T const &x) {
     return x.hashcode();
 }
 
+// @safe - returns char value
 template <>
 inline hashcode_t hashcode(char const &x) {
     return x;
 }
 
+// @safe - returns signed char value
 template <>
 inline hashcode_t hashcode(signed char const &x) {
     return x;
 }
 
+// @safe - returns unsigned char value
 template <>
 inline hashcode_t hashcode(unsigned char const &x) {
     return x;
 }
 
+// @safe - returns short value
 template <>
 inline hashcode_t hashcode(short const &x) {
     return x;
 }
 
+// @safe - returns unsigned short value
 template <>
 inline hashcode_t hashcode(unsigned short const &x) {
     return x;
 }
 
+// @safe - returns int value
 template <>
 inline hashcode_t hashcode(int const &x) {
     return x;
 }
 
+// @safe - returns unsigned value
 template <>
 inline hashcode_t hashcode(unsigned const &x) {
     return x;
 }
 
+// @safe - returns long value
 template <>
 inline hashcode_t hashcode(long const &x) {
     return x;
 }
 
+// @safe - returns unsigned long value
 template <>
 inline hashcode_t hashcode(unsigned long const &x) {
     return x;
 }
 
+// @safe - pure arithmetic on long long
 template <>
 inline hashcode_t hashcode(long long const &x) {
     return (x >> 32) ^ x;
 }
 
+// @safe - pure arithmetic on unsigned long long
 template <>
 inline hashcode_t hashcode(unsigned long long const &x) {
     return (x >> 32) ^ x;
 }
 
 #if HAVE_INT64_TYPES && !HAVE_INT64_IS_LONG && !HAVE_INT64_IS_LONG_LONG
+// @safe - pure arithmetic on int64_t
 template <>
 inline hashcode_t hashcode(int64_t const &x) {
     return (x >> 32) ^ x;
 }
 
+// @safe - pure arithmetic on uint64_t
 template <>
 inline hashcode_t hashcode(uint64_t const &x) {
     return (x >> 32) ^ x;
@@ -118,6 +131,7 @@ inline hashcode_t hashcode(T * const &x) {
 }
 
 template <typename T>
+// @safe - delegates to T::hashkey() method
 inline typename T::key_const_reference hashkey(const T &x) {
     return x.hashkey();
 }

--- a/src/mako/masstree/json.cc
+++ b/src/mako/masstree/json.cc
@@ -28,6 +28,7 @@
 //
 // @external: {
 //   lcdf::String: [unsafe_type]
+//   hashcode: [unsafe]
 // }
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*

--- a/src/mako/masstree/json.cc
+++ b/src/mako/masstree/json.cc
@@ -17,7 +17,18 @@
 // JSON parsing and serialization implementation
 // Most functions use malloc/pointer operations - @unsafe marked individually
 //
-// @external_unsafe_type: std::*
+// SAFETY NOTE: Most functions cannot be made safe because:
+// 1. ArrayJson/ObjectJson use placement new and manual destructor calls
+// 2. Memory management uses raw new[]/delete[] for flexible array members
+// 3. String parsing requires raw pointer arithmetic over input buffers
+// 4. The internal representation uses union types with manual lifetime management
+// 5. Reference counting is done manually, not via smart pointers
+//
+// Only pure helper functions like in_range() are marked @safe.
+//
+// @external: {
+//   lcdf::String: [unsafe_type]
+// }
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: lcdf::StringAccum::*

--- a/src/mako/masstree/json.cc
+++ b/src/mako/masstree/json.cc
@@ -1,3 +1,6 @@
+// @unsafe - JSON parsing and serialization implementation
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2014 President and Fellows of Harvard College
@@ -14,8 +17,7 @@
  * is legally binding.
  */
 // -*- c-basic-offset: 4 -*-
-// JSON parsing and serialization implementation
-// Most functions use malloc/pointer operations - @unsafe marked individually
+// Most functions use malloc/pointer operations
 //
 // SAFETY NOTE: Most functions cannot be made safe because:
 // 1. ArrayJson/ObjectJson use placement new and manual destructor calls
@@ -30,7 +32,6 @@
 //   lcdf::String: [unsafe_type]
 //   hashcode: [unsafe]
 // }
-// @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: lcdf::StringAccum::*
 // @external_unsafe: malloc

--- a/src/mako/masstree/json.cc
+++ b/src/mako/masstree/json.cc
@@ -566,6 +566,7 @@ Json& Json::hard_get_insert(size_type x) {
     }
 }
 
+// @safe - pure value comparison (String copy is safe by value)
 bool operator==(const Json& a, const Json& b) {
     if ((a.u_.x.type > 0 || b.u_.x.type > 0)
         && a.u_.x.type != b.u_.x.type)
@@ -590,6 +591,7 @@ bool operator==(const Json& a, const Json& b) {
 
 Json::unparse_manipulator Json::default_manipulator;
 
+// @unsafe - accesses raw object/array pointers
 bool Json::unparse_is_complex() const {
     if (is_object()) {
         if (ObjectJson *oj = ojson()) {

--- a/src/mako/masstree/json.hh
+++ b/src/mako/masstree/json.hh
@@ -817,7 +817,7 @@ class Json::const_iterator { public:
         ++i_;
         fix();
     }
-    // @safe - delegates to prefix increment
+    // @unsafe - overload must match prefix version's annotation
     void operator++(int) {
         ++(*this);
     }
@@ -1596,16 +1596,17 @@ inline const Json_get_proxy Json_proxy_base<T>::get(Str key, String& x) const {
 }
 
 
-// @safe - initializes union to zero
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 /** @brief Construct a null Json. */
 inline Json::Json() {
     memset(&u_, 0, sizeof(u_));
 }
-// @safe - initializes union to zero
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 /** @brief Construct a null Json. */
 inline Json::Json(const null_t&) {
     memset(&u_, 0, sizeof(u_));
 }
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 /** @brief Construct a Json copy of @a x. */
 inline Json::Json(const Json& x)
     : u_(x.u_) {
@@ -1614,6 +1615,7 @@ inline Json::Json(const Json& x)
     if (u_.x.x && (u_.x.type == j_array || u_.x.type == j_object))
         u_.x.x->ref();
 }
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 /** @overload */
 template <typename P> inline Json::Json(const Json_proxy_base<P>& x)
     : u_(x.cvalue().u_) {
@@ -1622,6 +1624,7 @@ template <typename P> inline Json::Json(const Json_proxy_base<P>& x)
     if (u_.x.x && (u_.x.type == j_array || u_.x.type == j_object))
         u_.x.x->ref();
 }
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 #if HAVE_CXX_RVALUE_REFERENCES
 /** @overload */
 inline Json::Json(Json&& x)
@@ -1629,43 +1632,43 @@ inline Json::Json(Json&& x)
     memset(&x, 0, sizeof(x));
 }
 #endif
-// @safe - pure value initialization
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 /** @brief Construct simple Json values. */
 inline Json::Json(int x) {
     u_.i.x = x;
     u_.i.type = j_int;
 }
-// @safe - pure value initialization
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 inline Json::Json(unsigned x) {
     u_.u.x = x;
     u_.u.type = j_unsigned;
 }
-// @safe - pure value initialization
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 inline Json::Json(long x) {
     u_.i.x = x;
     u_.i.type = j_int;
 }
-// @safe - pure value initialization
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 inline Json::Json(unsigned long x) {
     u_.u.x = x;
     u_.u.type = j_unsigned;
 }
-// @safe - pure value initialization
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 inline Json::Json(long long x) {
     u_.i.x = x;
     u_.i.type = j_int;
 }
-// @safe - pure value initialization
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 inline Json::Json(unsigned long long x) {
     u_.u.x = x;
     u_.u.type = j_unsigned;
 }
-// @safe - pure value initialization
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 inline Json::Json(double x) {
     u_.d.x = x;
     u_.d.type = j_double;
 }
-// @safe - pure value initialization
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 inline Json::Json(bool x) {
     u_.i.x = x;
     u_.i.type = j_bool;
@@ -1693,6 +1696,7 @@ inline Json::Json(const char* x) {
     String str(x);
     str.swap(u_.str);
 }
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 /** @brief Construct an array Json containing the elements of @a x. */
 template <typename T>
 inline Json::Json(const std::vector<T> &x) {
@@ -1721,6 +1725,7 @@ struct Json_iterator_initializer<std::pair<T, U> > {
     }
 };
 
+// @unsafe - shares name with unsafe overloads (overload annotation conflict)
 /** @brief Construct an array Json containing the elements in [@a first,
     @a last). */
 template <typename T>

--- a/src/mako/masstree/json.hh
+++ b/src/mako/masstree/json.hh
@@ -505,11 +505,13 @@ inline void Json::ComplexJson::deref(json_type j) {
     }
 }
 
+// @unsafe - returns raw pointer to internal array storage
 inline Json::ArrayJson* Json::ajson() const {
     precondition(u_.x.type == j_null || u_.x.type == j_array);
     return u_.a.x;
 }
 
+// @unsafe - returns raw pointer to internal object storage
 inline Json::ObjectJson* Json::ojson() const {
     precondition(u_.x.type == j_null || u_.x.type == j_object);
     return u_.o.x;
@@ -721,44 +723,55 @@ class Json::array_iterator : public const_array_iterator { public:
     friend class Json;
 };
 
+// @safe - pure pointer and index comparison
 inline bool operator==(const Json::const_array_iterator& a, const Json::const_array_iterator& b) {
     return a.j_ == b.j_ && a.i_ == b.i_;
 }
 
+// @safe - pure pointer and index comparison
 inline bool operator<(const Json::const_array_iterator& a, const Json::const_array_iterator& b) {
     return a.j_ < b.j_ || (a.j_ == b.j_ && a.i_ < b.i_);
 }
 
+// @safe - delegates to operator==
 inline bool operator!=(const Json::const_array_iterator& a, const Json::const_array_iterator& b) {
     return !(a == b);
 }
 
+// @safe - delegates to operator<
 inline bool operator<=(const Json::const_array_iterator& a, const Json::const_array_iterator& b) {
     return !(b < a);
 }
 
+// @safe - delegates to operator<
 inline bool operator>(const Json::const_array_iterator& a, const Json::const_array_iterator& b) {
     return b < a;
 }
 
+// @safe - delegates to operator<
 inline bool operator>=(const Json::const_array_iterator& a, const Json::const_array_iterator& b) {
     return !(a < b);
 }
 
+// @safe - pure arithmetic
 inline Json::const_array_iterator operator+(Json::const_array_iterator a, Json::const_array_iterator::difference_type i) {
     return a += i;
 }
+// @safe - pure arithmetic
 inline Json::array_iterator operator+(Json::array_iterator a, Json::array_iterator::difference_type i) {
     return a += i;
 }
 
+// @safe - pure arithmetic
 inline Json::const_array_iterator operator-(Json::const_array_iterator a, Json::const_array_iterator::difference_type i) {
     return a -= i;
 }
+// @safe - pure arithmetic
 inline Json::array_iterator operator-(Json::array_iterator a, Json::array_iterator::difference_type i) {
     return a -= i;
 }
 
+// @safe - pure arithmetic subtraction
 inline Json::const_array_iterator::difference_type operator-(const Json::const_array_iterator& a, const Json::const_array_iterator& b) {
     precondition(a.j_ == b.j_);
     return a.i_ - b.i_;
@@ -770,32 +783,41 @@ class Json::const_iterator { public:
     typedef const value_type& reference;
     typedef std::forward_iterator_tag iterator_category;
 
+    // @unsafe - initializes with invalid reference
     const_iterator()
         : value_(String(), *(Json*) 0) {
     }
     typedef bool (const_iterator::*unspecified_bool_type)() const;
+    // @safe - pure value check
     operator unspecified_bool_type() const {
         return live() ? &const_iterator::live : 0;
     }
+    // @safe - pure index comparison
     bool live() const {
         return i_ >= 0;
     }
+    // @unsafe - returns reference to internal value
     const value_type& operator*() const {
         return value_;
     }
+    // @unsafe - returns pointer to internal value
     const value_type* operator->() const {
         return &(**this);
     }
+    // @unsafe - returns reference via dereference
     const String& key() const {
         return (**this).first;
     }
+    // @unsafe - returns reference via dereference
     const Json& value() const {
         return (**this).second;
     }
+    // @unsafe - modifies state and calls fix()
     void operator++() {
         ++i_;
         fix();
     }
+    // @safe - delegates to prefix increment
     void operator++(int) {
         ++(*this);
     }
@@ -867,210 +889,278 @@ class Json::iterator : public const_iterator { public:
     friend class Json;
 };
 
+// @safe - pure pointer and index comparison
 inline bool operator==(const Json::const_iterator& a, const Json::const_iterator& b) {
     return a.j_ == b.j_ && a.i_ == b.i_;
 }
 
+// @safe - delegates to operator==
 inline bool operator!=(const Json::const_iterator& a, const Json::const_iterator& b) {
     return !(a == b);
 }
 
 
+// @unsafe - CRTP proxy base with reference-returning methods
 template <typename P>
 class Json_proxy_base {
   public:
+    // @unsafe - returns reference via CRTP cast
     const Json& cvalue() const {
         return static_cast<const P *>(this)->cvalue();
     }
+    // @unsafe - returns mutable reference via CRTP cast
     Json& value() {
         return static_cast<P *>(this)->value();
     }
+    // @unsafe - returns reference
     operator const Json&() const {
         return cvalue();
     }
+    // @unsafe - returns mutable reference
     operator Json&() {
         return value();
     }
+    // @safe - delegates to safe truthy()
     bool truthy() const {
         return cvalue().truthy();
     }
+    // @safe - delegates to safe falsy()
     bool falsy() const {
         return cvalue().falsy();
     }
+    // @safe - bool conversion
     operator Json::unspecified_bool_type() const {
         return cvalue();
     }
+    // @safe - negation
     bool operator!() const {
         return !cvalue();
     }
+    // @safe - delegates to safe is_null()
     bool is_null() const {
         return cvalue().is_null();
     }
+    // @safe - delegates to safe is_int()
     bool is_int() const {
         return cvalue().is_int();
     }
+    // @safe - delegates to safe is_i()
     bool is_i() const {
         return cvalue().is_i();
     }
+    // @safe - delegates to safe is_unsigned()
     bool is_unsigned() const {
         return cvalue().is_unsigned();
     }
+    // @safe - delegates to safe is_u()
     bool is_u() const {
         return cvalue().is_u();
     }
+    // @safe - delegates to safe is_signed()
     bool is_signed() const {
         return cvalue().is_signed();
     }
+    // @safe - delegates to safe is_nonnegint()
     bool is_nonnegint() const {
         return cvalue().is_nonnegint();
     }
+    // @safe - delegates to safe is_double()
     bool is_double() const {
         return cvalue().is_double();
     }
+    // @safe - delegates to safe is_d()
     bool is_d() const {
         return cvalue().is_d();
     }
+    // @safe - delegates to safe is_number()
     bool is_number() const {
         return cvalue().is_number();
     }
+    // @safe - delegates to safe is_n()
     bool is_n() const {
         return cvalue().is_n();
     }
+    // @safe - delegates to safe is_bool()
     bool is_bool() const {
         return cvalue().is_bool();
     }
+    // @safe - delegates to safe is_b()
     bool is_b() const {
         return cvalue().is_b();
     }
+    // @safe - delegates to safe is_string()
     bool is_string() const {
         return cvalue().is_string();
     }
+    // @safe - delegates to safe is_s()
     bool is_s() const {
         return cvalue().is_s();
     }
+    // @safe - delegates to safe is_array()
     bool is_array() const {
         return cvalue().is_array();
     }
+    // @safe - delegates to safe is_a()
     bool is_a() const {
         return cvalue().is_a();
     }
+    // @safe - delegates to safe is_object()
     bool is_object() const {
         return cvalue().is_object();
     }
+    // @safe - delegates to safe is_o()
     bool is_o() const {
         return cvalue().is_o();
     }
+    // @safe - delegates to safe is_primitive()
     bool is_primitive() const {
         return cvalue().is_primitive();
     }
+    // @safe - delegates to safe empty()
     bool empty() const {
         return cvalue().empty();
     }
+    // @safe - delegates to safe size()
     Json::size_type size() const {
         return cvalue().size();
     }
+    // @safe - delegates to safe to_i()
     int64_t to_i() const {
         return cvalue().to_i();
     }
+    // @safe - delegates to safe to_u()
     uint64_t to_u() const {
         return cvalue().to_u();
     }
+    // @safe - delegates to safe to_u64()
     uint64_t to_u64() const {
         return cvalue().to_u64();
     }
+    // @safe - delegates to safe to_i(int&)
     bool to_i(int& x) const {
         return cvalue().to_i(x);
     }
+    // @safe - delegates to safe to_i(unsigned&)
     bool to_i(unsigned& x) const {
         return cvalue().to_i(x);
     }
+    // @safe - delegates to safe to_i(long&)
     bool to_i(long& x) const {
         return cvalue().to_i(x);
     }
+    // @safe - delegates to safe to_i(unsigned long&)
     bool to_i(unsigned long& x) const {
         return cvalue().to_i(x);
     }
+    // @safe - delegates to safe to_i(long long&)
     bool to_i(long long& x) const {
         return cvalue().to_i(x);
     }
+    // @safe - delegates to safe to_i(unsigned long long&)
     bool to_i(unsigned long long& x) const {
         return cvalue().to_i(x);
     }
+    // @safe - delegates to safe as_i()
     int64_t as_i() const {
         return cvalue().as_i();
     }
+    // @safe - delegates to safe as_i(default)
     int64_t as_i(int64_t default_value) const {
         return cvalue().as_i(default_value);
     }
+    // @safe - delegates to safe as_u()
     uint64_t as_u() const {
         return cvalue().as_u();
     }
+    // @safe - delegates to safe as_u(default)
     uint64_t as_u(uint64_t default_value) const {
         return cvalue().as_u(default_value);
     }
+    // @safe - delegates to safe to_d()
     double to_d() const {
         return cvalue().to_d();
     }
+    // @safe - delegates to safe to_d(double&)
     bool to_d(double& x) const {
         return cvalue().to_d(x);
     }
+    // @safe - delegates to safe as_d()
     double as_d() const {
         return cvalue().as_d();
     }
+    // @safe - delegates to safe as_d(default)
     double as_d(double default_value) const {
         return cvalue().as_d(default_value);
     }
+    // @safe - delegates to safe to_b()
     bool to_b() const {
         return cvalue().to_b();
     }
+    // @safe - delegates to safe to_b(bool&)
     bool to_b(bool& x) const {
         return cvalue().to_b(x);
     }
+    // @safe - delegates to safe as_b()
     bool as_b() const {
         return cvalue().as_b();
     }
+    // @safe - delegates to safe as_b(default)
     bool as_b(bool default_value) const {
         return cvalue().as_b(default_value);
     }
+    // @safe - returns string by value
     String to_s() const {
         return cvalue().to_s();
     }
+    // @safe - delegates to safe to_s(Str&)
     bool to_s(Str& x) const {
         return cvalue().to_s(x);
     }
+    // @safe - delegates to safe to_s(String&)
     bool to_s(String& x) const {
         return cvalue().to_s(x);
     }
+    // @unsafe - returns reference
     const String& as_s() const {
         return cvalue().as_s();
     }
+    // @unsafe - returns reference
     const String& as_s(const String& default_value) const {
         return cvalue().as_s(default_value);
     }
+    // @safe - pure value accessor
     Json::size_type count(Str key) const {
         return cvalue().count(key);
     }
+    // @unsafe - returns reference
     const Json& get(Str key) const {
         return cvalue().get(key);
     }
+    // @unsafe - returns mutable reference
     Json& get_insert(const String& key) {
         return value().get_insert(key);
     }
+    // @unsafe - returns mutable reference
     Json& get_insert(Str key) {
         return value().get_insert(key);
     }
+    // @unsafe - returns mutable reference
     Json& get_insert(const char* key) {
         return value().get_insert(key);
     }
+    // @safe - pure value accessor
     long get_i(Str key) const {
         return cvalue().get_i(key);
     }
+    // @safe - pure value accessor
     double get_d(Str key) const {
         return cvalue().get_d(key);
     }
+    // @safe - pure value accessor
     bool get_b(Str key) const {
         return cvalue().get_b(key);
     }
+    // @safe - returns by value
     String get_s(Str key) const {
         return cvalue().get_s(key);
     }
@@ -1449,56 +1539,69 @@ class Json_get_proxy : public Json_proxy_base<Json_get_proxy> {
     Json_get_proxy& operator=(const Json_get_proxy& x);
 };
 
+// @unsafe - delegates to cvalue().get() with output reference
 template <typename T>
 inline const Json_get_proxy Json_proxy_base<T>::get(Str key, Json& x) const {
     return cvalue().get(key, x);
 }
+// @unsafe - delegates to cvalue().get() with output reference
 template <typename T>
 inline const Json_get_proxy Json_proxy_base<T>::get(Str key, int& x) const {
     return cvalue().get(key, x);
 }
+// @unsafe - delegates to cvalue().get() with output reference
 template <typename T>
 inline const Json_get_proxy Json_proxy_base<T>::get(Str key, unsigned& x) const {
     return cvalue().get(key, x);
 }
+// @unsafe - delegates to cvalue().get() with output reference
 template <typename T>
 inline const Json_get_proxy Json_proxy_base<T>::get(Str key, long& x) const {
     return cvalue().get(key, x);
 }
+// @unsafe - delegates to cvalue().get() with output reference
 template <typename T>
 inline const Json_get_proxy Json_proxy_base<T>::get(Str key, unsigned long& x) const {
     return cvalue().get(key, x);
 }
+// @unsafe - delegates to cvalue().get() with output reference
 template <typename T>
 inline const Json_get_proxy Json_proxy_base<T>::get(Str key, long long& x) const {
     return cvalue().get(key, x);
 }
+// @unsafe - delegates to cvalue().get() with output reference
 template <typename T>
 inline const Json_get_proxy Json_proxy_base<T>::get(Str key, unsigned long long& x) const {
     return cvalue().get(key, x);
 }
+// @unsafe - delegates to cvalue().get() with output reference
 template <typename T>
 inline const Json_get_proxy Json_proxy_base<T>::get(Str key, double& x) const {
     return cvalue().get(key, x);
 }
+// @unsafe - delegates to cvalue().get() with output reference
 template <typename T>
 inline const Json_get_proxy Json_proxy_base<T>::get(Str key, bool& x) const {
     return cvalue().get(key, x);
 }
+// @unsafe - delegates to cvalue().get() with output reference
 template <typename T>
 inline const Json_get_proxy Json_proxy_base<T>::get(Str key, Str& x) const {
     return cvalue().get(key, x);
 }
+// @unsafe - delegates to cvalue().get() with output reference
 template <typename T>
 inline const Json_get_proxy Json_proxy_base<T>::get(Str key, String& x) const {
     return cvalue().get(key, x);
 }
 
 
+// @safe - initializes union to zero
 /** @brief Construct a null Json. */
 inline Json::Json() {
     memset(&u_, 0, sizeof(u_));
 }
+// @safe - initializes union to zero
 /** @brief Construct a null Json. */
 inline Json::Json(const null_t&) {
     memset(&u_, 0, sizeof(u_));
@@ -1526,53 +1629,65 @@ inline Json::Json(Json&& x)
     memset(&x, 0, sizeof(x));
 }
 #endif
+// @safe - pure value initialization
 /** @brief Construct simple Json values. */
 inline Json::Json(int x) {
     u_.i.x = x;
     u_.i.type = j_int;
 }
+// @safe - pure value initialization
 inline Json::Json(unsigned x) {
     u_.u.x = x;
     u_.u.type = j_unsigned;
 }
+// @safe - pure value initialization
 inline Json::Json(long x) {
     u_.i.x = x;
     u_.i.type = j_int;
 }
+// @safe - pure value initialization
 inline Json::Json(unsigned long x) {
     u_.u.x = x;
     u_.u.type = j_unsigned;
 }
+// @safe - pure value initialization
 inline Json::Json(long long x) {
     u_.i.x = x;
     u_.i.type = j_int;
 }
+// @safe - pure value initialization
 inline Json::Json(unsigned long long x) {
     u_.u.x = x;
     u_.u.type = j_unsigned;
 }
+// @safe - pure value initialization
 inline Json::Json(double x) {
     u_.d.x = x;
     u_.d.type = j_double;
 }
+// @safe - pure value initialization
 inline Json::Json(bool x) {
     u_.i.x = x;
     u_.i.type = j_bool;
 }
+// @unsafe - uses reference counting on String
 inline Json::Json(const String& x) {
     u_.str = x.internal_rep();
     u_.str.ref();
 }
+// @unsafe - uses reference counting on String
 inline Json::Json(const std::string& x) {
     u_.str.reset_ref();
     String str(x);
     str.swap(u_.str);
 }
+// @unsafe - uses reference counting on String
 inline Json::Json(Str x) {
     u_.str.reset_ref();
     String str(x);
     str.swap(u_.str);
 }
+// @unsafe - uses reference counting on String
 inline Json::Json(const char* x) {
     u_.str.reset_ref();
     String str(x);
@@ -1677,101 +1792,128 @@ inline Json Json::make_string(const char *s, int len) {
 }
 
 /** @brief Test if this Json is truthy. */
+// @safe - pure value comparison
 inline bool Json::truthy() const {
     return (u_.x.x ? u_.x.type >= 0 || u_.str.length
             : (unsigned) (u_.x.type - 1) < (unsigned) (j_int - 1));
 }
 /** @brief Test if this Json is falsy. */
+// @safe - delegates to safe truthy()
 inline bool Json::falsy() const {
     return !truthy();
 }
 /** @brief Test if this Json is truthy.
     @sa empty() */
+// @safe - delegates to safe truthy()
 inline Json::operator unspecified_bool_type() const {
     return truthy() ? &Json::is_null : 0;
 }
 /** @brief Return true if this Json is falsy. */
+// @safe - delegates to safe truthy()
 inline bool Json::operator!() const {
     return !truthy();
 }
 
 /** @brief Test this Json's type. */
+// @safe - pure type comparison
 inline bool Json::is_null() const {
     return !u_.x.x && u_.x.type == j_null;
 }
+// @safe - pure type comparison
 inline bool Json::is_int() const {
     return unsigned(u_.x.type - j_int) <= unsigned(j_unsigned - j_int);
 }
+// @safe - delegates to is_int
 inline bool Json::is_i() const {
     return is_int();
 }
+// @safe - pure type comparison
 inline bool Json::is_unsigned() const {
     return u_.x.type == j_unsigned;
 }
+// @safe - delegates to is_unsigned
 inline bool Json::is_u() const {
     return is_unsigned();
 }
+// @safe - pure type comparison
 inline bool Json::is_signed() const {
     return u_.x.type == j_int;
 }
+// @safe - pure value comparison
 inline bool Json::is_nonnegint() const {
     return u_.x.type == j_unsigned
         || (u_.x.type == j_int && u_.i.x >= 0);
 }
+// @safe - pure type comparison
 inline bool Json::is_double() const {
     return u_.x.type == j_double;
 }
+// @safe - delegates to is_double
 inline bool Json::is_d() const {
     return is_double();
 }
+// @safe - pure type comparison
 inline bool Json::is_number() const {
     return unsigned(u_.x.type - j_int) <= unsigned(j_double - j_int);
 }
+// @safe - delegates to is_number
 inline bool Json::is_n() const {
     return is_number();
 }
+// @safe - pure type comparison
 inline bool Json::is_bool() const {
     return u_.x.type == j_bool;
 }
+// @safe - delegates to is_bool
 inline bool Json::is_b() const {
     return is_bool();
 }
+// @safe - pure type and pointer comparison
 inline bool Json::is_string() const {
     return u_.x.x && u_.x.type <= 0;
 }
+// @safe - delegates to is_string
 inline bool Json::is_s() const {
     return is_string();
 }
+// @safe - pure type comparison
 inline bool Json::is_array() const {
     return u_.x.type == j_array;
 }
+// @safe - delegates to is_array
 inline bool Json::is_a() const {
     return is_array();
 }
+// @safe - pure type comparison
 inline bool Json::is_object() const {
     return u_.x.type == j_object;
 }
+// @safe - delegates to is_object
 inline bool Json::is_o() const {
     return is_object();
 }
 /** @brief Test if this Json is a primitive value, not including null. */
+// @safe - pure type and pointer comparison
 inline bool Json::is_primitive() const {
     return u_.x.type >= j_int || (u_.x.x && u_.x.type <= 0);
 }
 
 /** @brief Return true if this Json is null, an empty array, or an empty
     object. */
+// @safe - pure value comparison
 inline bool Json::empty() const {
     return unsigned(u_.x.type) < unsigned(j_int)
         && (!u_.x.x || u_.x.x->size == 0);
 }
 /** @brief Return the number of elements in this complex Json.
     @pre is_array() || is_object() || is_null() */
+// @safe - pure value access
 inline Json::size_type Json::size() const {
     precondition(unsigned(u_.x.type) < unsigned(j_int));
     return u_.x.x ? u_.x.x->size : 0;
 }
 /** @brief Test if this complex Json is shared. */
+// @safe - pure value comparison
 inline bool Json::shared() const {
     return u_.x.x && (u_.x.type == j_array || u_.x.type == j_object)
         && u_.x.x->refcount != 1;
@@ -1786,6 +1928,7 @@ inline bool Json::shared() const {
     boolean Jsons to 1; string Jsons to a number parsed from their initial
     portions; and array and object Jsons to size().
     @sa as_i() */
+// @safe - pure value extraction (or calls hard_to_i for non-int)
 inline int64_t Json::to_i() const {
     if (is_int())
         return u_.i.x;
@@ -1793,6 +1936,7 @@ inline int64_t Json::to_i() const {
         return hard_to_i();
 }
 
+// @safe - pure value extraction (or calls hard_to_u for non-int)
 inline uint64_t Json::to_u() const {
     if (is_int())
         return u_.u.x;
@@ -1806,6 +1950,7 @@ inline uint64_t Json::to_u() const {
 
     If false is returned (!is_number() or the number is not parseable as a
     pure integer), @a x remains unchanged. */
+// @safe - pure value extraction
 inline bool Json::to_i(int& x) const {
     if (is_int()) {
         x = u_.i.x;
@@ -1818,6 +1963,7 @@ inline bool Json::to_i(int& x) const {
 }
 
 /** @overload */
+// @safe - pure value extraction
 inline bool Json::to_i(unsigned& x) const {
     if (is_int()) {
         x = u_.u.x;
@@ -1830,6 +1976,7 @@ inline bool Json::to_i(unsigned& x) const {
 }
 
 /** @overload */
+// @safe - pure value extraction
 inline bool Json::to_i(long& x) const {
     if (is_int()) {
         x = u_.i.x;
@@ -1842,6 +1989,7 @@ inline bool Json::to_i(long& x) const {
 }
 
 /** @overload */
+// @safe - pure value extraction
 inline bool Json::to_i(unsigned long& x) const {
     if (is_int()) {
         x = u_.u.x;
@@ -1854,6 +2002,7 @@ inline bool Json::to_i(unsigned long& x) const {
 }
 
 /** @overload */
+// @safe - pure value extraction
 inline bool Json::to_i(long long& x) const {
     if (is_int()) {
         x = u_.i.x;
@@ -1866,6 +2015,7 @@ inline bool Json::to_i(long long& x) const {
 }
 
 /** @overload */
+// @safe - pure value extraction
 inline bool Json::to_i(unsigned long long& x) const {
     if (is_int()) {
         x = u_.u.x;
@@ -1880,6 +2030,7 @@ inline bool Json::to_i(unsigned long long& x) const {
 /** @brief Return this Json converted to a 64-bit unsigned integer.
 
     See to_i() for the conversion rules. */
+// @safe - delegates to safe to_u
 inline uint64_t Json::to_u64() const {
     return to_u();
 }
@@ -1887,12 +2038,14 @@ inline uint64_t Json::to_u64() const {
 /** @brief Return the integer value of this numeric Json.
     @pre is_number()
     @sa to_i() */
+// @safe - pure value extraction
 inline int64_t Json::as_i() const {
     precondition(is_int() || is_double());
     return is_int() ? u_.i.x : int64_t(u_.d.x);
 }
 
 /** @brief Return the integer value of this numeric Json or @a default_value. */
+// @safe - pure value extraction
 inline int64_t Json::as_i(int64_t default_value) const {
     if (is_int() || is_double())
         return as_i();
@@ -1903,12 +2056,14 @@ inline int64_t Json::as_i(int64_t default_value) const {
 /** @brief Return the unsigned integer value of this numeric Json.
     @pre is_number()
     @sa to_i() */
+// @safe - pure value extraction
 inline uint64_t Json::as_u() const {
     precondition(is_int() || is_double());
     return is_int() ? u_.u.x : uint64_t(u_.d.x);
 }
 
 /** @brief Return the integer value of this numeric Json or @a default_value. */
+// @safe - pure value extraction
 inline uint64_t Json::as_u(uint64_t default_value) const {
     if (is_int() || is_double())
         return as_u();
@@ -1923,6 +2078,7 @@ inline uint64_t Json::as_u(uint64_t default_value) const {
     boolean Jsons to 1; string Jsons to a number parsed from their initial
     portions; and array and object Jsons to size().
     @sa as_d() */
+// @safe - pure value extraction (or calls hard_to_d for non-double)
 inline double Json::to_d() const {
     if (is_double())
         return u_.d.x;
@@ -1935,6 +2091,7 @@ inline double Json::to_d() const {
     @return True iff is_number().
 
     If !is_number(), @a x remains unchanged. */
+// @safe - pure value extraction
 inline bool Json::to_d(double& x) const {
     if (is_double() || is_int()) {
         x = to_d();
@@ -1946,6 +2103,7 @@ inline bool Json::to_d(double& x) const {
 /** @brief Return the double value of this numeric Json.
     @pre is_number()
     @sa to_d() */
+// @safe - pure value extraction
 inline double Json::as_d() const {
     precondition(is_double() || is_int());
     if (is_double())
@@ -1957,6 +2115,7 @@ inline double Json::as_d() const {
 }
 
 /** @brief Return the double value of this numeric Json or @a default_value. */
+// @safe - pure value extraction
 inline double Json::as_d(double default_value) const {
     if (!is_double() && !is_int())
         return default_value;
@@ -1971,6 +2130,7 @@ inline double Json::as_d(double default_value) const {
     and other numeric Jsons to true; empty string Jsons to false, and other
     string Jsons to true; and array and object Jsons to !empty().
     @sa as_b() */
+// @safe - pure value extraction (or calls hard_to_b for non-bool)
 inline bool Json::to_b() const {
     if (is_bool())
         return u_.i.x;
@@ -1983,6 +2143,7 @@ inline bool Json::to_b() const {
     @return True iff is_bool().
 
     If !is_bool(), @a x remains unchanged. */
+// @safe - pure value extraction
 inline bool Json::to_b(bool& x) const {
     if (is_bool()) {
         x = u_.i.x;
@@ -1994,12 +2155,14 @@ inline bool Json::to_b(bool& x) const {
 /** @brief Return the value of this boolean Json.
     @pre is_bool()
     @sa to_b() */
+// @safe - pure value extraction
 inline bool Json::as_b() const {
     precondition(is_bool());
     return u_.i.x;
 }
 
 /** @brief Return the boolean value of this numeric Json or @a default_value. */
+// @safe - pure value extraction
 inline bool Json::as_b(bool default_value) const {
     if (is_bool())
         return as_b();
@@ -2712,44 +2875,55 @@ inline Json::const_iterator Json::end() const {
 
 
 // Unparsing
+// @safe - Pure value type for JSON formatting options
 class Json::unparse_manipulator {
   public:
+    // @safe - default initialization
     unparse_manipulator()
         : indent_depth_(0), tab_width_(0), newline_terminator_(false),
           space_separator_(false) {
     }
+    // @safe - returns stored value
     int indent_depth() const {
         return indent_depth_;
     }
+    // @unsafe - copy via *this dereference
     unparse_manipulator indent_depth(int x) const {
         unparse_manipulator m(*this);
         m.indent_depth_ = x;
         return m;
     }
+    // @safe - returns stored value
     int tab_width() const {
         return tab_width_;
     }
+    // @unsafe - copy via *this dereference
     unparse_manipulator tab_width(int x) const {
         unparse_manipulator m(*this);
         m.tab_width_ = x;
         return m;
     }
+    // @safe - returns stored value
     bool newline_terminator() const {
         return newline_terminator_;
     }
+    // @unsafe - copy via *this dereference
     unparse_manipulator newline_terminator(bool x) const {
         unparse_manipulator m(*this);
         m.newline_terminator_ = x;
         return m;
     }
+    // @safe - returns stored value
     bool space_separator() const {
         return space_separator_;
     }
+    // @unsafe - copy via *this dereference
     unparse_manipulator space_separator(bool x) const {
         unparse_manipulator m(*this);
         m.space_separator_ = x;
         return m;
     }
+    // @safe - pure value comparison
     bool empty() const {
         return !indent_depth_ && !newline_terminator_ && !space_separator_;
     }
@@ -2760,15 +2934,19 @@ class Json::unparse_manipulator {
     bool space_separator_;
 };
 
+// @safe - returns copy of manipulator with indent_depth
 inline Json::unparse_manipulator Json::indent_depth(int x) {
     return unparse_manipulator().indent_depth(x);
 }
+// @safe - returns copy of manipulator with tab_width
 inline Json::unparse_manipulator Json::tab_width(int x) {
     return unparse_manipulator().tab_width(x);
 }
+// @safe - returns copy of manipulator with newline_terminator
 inline Json::unparse_manipulator Json::newline_terminator(bool x) {
     return unparse_manipulator().newline_terminator(x);
 }
+// @safe - returns copy of manipulator with space_separator
 inline Json::unparse_manipulator Json::space_separator(bool x) {
     return unparse_manipulator().space_separator(x);
 }
@@ -2874,10 +3052,12 @@ inline bool Json::streaming_parser::success() const {
     return state_ == st_final;
 }
 
+// @safe - pure state comparison
 inline bool Json::streaming_parser::error() const {
     return state_ == st_error;
 }
 
+// @unsafe - processes raw pointers
 inline size_t Json::streaming_parser::consume(const char* first, size_t length,
                                               const String& str,
                                               bool complete) {
@@ -2885,6 +3065,7 @@ inline size_t Json::streaming_parser::consume(const char* first, size_t length,
     return consume(ufirst, ufirst + length, str, complete) - ufirst;
 }
 
+// @unsafe - processes raw pointers
 inline const char* Json::streaming_parser::consume(const char* first,
                                                    const char* last,
                                                    const String& str,
@@ -2894,10 +3075,12 @@ inline const char* Json::streaming_parser::consume(const char* first,
                  reinterpret_cast<const uint8_t*>(last), str, complete));
 }
 
+// @unsafe - returns mutable reference
 inline Json& Json::streaming_parser::result() {
     return json_;
 }
 
+// @unsafe - returns reference without lifetime tracking
 inline const Json& Json::streaming_parser::result() const {
     return json_;
 }

--- a/src/mako/masstree/json.hh
+++ b/src/mako/masstree/json.hh
@@ -346,6 +346,7 @@ class Json {
 
     friend bool operator==(const Json& a, const Json& b);
 
+    // @unsafe - swaps internal union representations
     inline void swap(Json& x);
 
   private:
@@ -3206,6 +3207,7 @@ inline bool operator!=(const Json_proxy_base<T>& a,
     return !(a == b);
 }
 
+// @unsafe - delegates to unsafe Json::swap
 inline void swap(Json& a, Json& b) {
     a.swap(b);
 }

--- a/src/mako/masstree/jsontest.cc
+++ b/src/mako/masstree/jsontest.cc
@@ -1,3 +1,6 @@
+// @unsafe - Test harness for JSON parsing and serialization
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
 // -*- c-basic-offset: 4 -*-
 /*
  * jsontest.{cc,hh} -- regression tests for Json
@@ -15,17 +18,13 @@
  * notice is a summary of the Click LICENSE file; the license in that file is
  * legally binding.
  */
-// Test harness for JSON parsing and serialization
-//
 // @external: {
 //   lcdf::String: [unsafe_type]
 //   htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe]
 //   hashcode: [unsafe]
 // }
-// @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: lcdf::Json::*
-
 #include "json.hh"
 #include <unordered_map>
 using namespace lcdf;

--- a/src/mako/masstree/jsontest.cc
+++ b/src/mako/masstree/jsontest.cc
@@ -19,6 +19,8 @@
 //
 // @external: {
 //   lcdf::String: [unsafe_type]
+//   htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe]
+//   hashcode: [unsafe]
 // }
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*

--- a/src/mako/masstree/jsontest.cc
+++ b/src/mako/masstree/jsontest.cc
@@ -17,7 +17,9 @@
  */
 // Test harness for JSON parsing and serialization
 //
-// @external_unsafe_type: std::*
+// @external: {
+//   lcdf::String: [unsafe_type]
+// }
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: lcdf::Json::*

--- a/src/mako/masstree/kpermuter.hh
+++ b/src/mako/masstree/kpermuter.hh
@@ -13,9 +13,9 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe - Key permutation array for sorted key access in Masstree nodes
+// @safe - Key permutation array for sorted key access in Masstree nodes
 // Encodes key ordering in packed bit fields for cache-efficient iteration
-// SAFETY: Uses bit manipulation and packed integer representation
+// All operations are pure bit manipulation on owned integer values
 
 #ifndef KPERMUTER_HH
 #define KPERMUTER_HH
@@ -150,7 +150,7 @@ template <int width> class kpermuter {
         <li>Given j with j == i, q[j] == x</li>
         <li>Given j with i < j < q.size(), q[j] == p[j-1] && q[j] != x</li>
         </ul> */
-    // @unsafe - updates packed permutation bits without additional bounds/lifetime tracking
+    // @safe - pure bit manipulation on owned value
     int insert_from_back(int i) {
         int value = back();
         // increment size, leave lower slots unchanged
@@ -197,7 +197,7 @@ template <int width> class kpermuter {
         <li>Given j with i <= j < q.size(), q[j] == p[j+1]</li>
         <li>q[q.size()] == p[i]</li>
         </ul> */
-    // @unsafe - mutates packed permutation bits directly
+    // @safe - pure bit manipulation on owned value
     void remove(int i) {
         (void) width;
         if (int(x_ & 15) == i + 1)
@@ -341,14 +341,16 @@ template <typename T> struct has_permuter_type {
 template <typename T, bool HP = has_permuter_type<T>::value> struct key_permuter {};
 template <typename T> struct key_permuter<T, true> {
     typedef typename T::permuter_type type;
-    // @unsafe - delegates to T::permutation() without safety guarantees
+    // @unsafe - calls method on template parameter which cannot be verified at analysis time
+    // SAFETY: T::permutation() is expected to be a pure accessor returning permuter state
     static type permutation(const T& n) {
         return n.permutation();
     }
 };
 template <typename T> struct key_permuter<T, false> {
     typedef identity_kpermuter type;
-    // @unsafe - calls n.size() without safety guarantees
+    // @unsafe - calls method on template parameter which cannot be verified at analysis time
+    // SAFETY: T::size() is expected to be a pure accessor returning size
     static type permutation(const T& n) {
         return identity_kpermuter(n.size());
     }

--- a/src/mako/masstree/kpermuter.hh
+++ b/src/mako/masstree/kpermuter.hh
@@ -16,7 +16,7 @@
 // @safe - Key permutation array for sorted key access in Masstree nodes
 // Encodes key ordering in packed bit fields for cache-efficient iteration
 // All operations are pure bit manipulation on owned integer values
-// @external_unsafe: assign
+// @external: { assign: [unsafe], htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe], hashcode: [unsafe] }
 
 #ifndef KPERMUTER_HH
 #define KPERMUTER_HH

--- a/src/mako/masstree/kpermuter.hh
+++ b/src/mako/masstree/kpermuter.hh
@@ -16,6 +16,7 @@
 // @safe - Key permutation array for sorted key access in Masstree nodes
 // Encodes key ordering in packed bit fields for cache-efficient iteration
 // All operations are pure bit manipulation on owned integer values
+// @external_unsafe: assign
 
 #ifndef KPERMUTER_HH
 #define KPERMUTER_HH

--- a/src/mako/masstree/kpermuter.hh
+++ b/src/mako/masstree/kpermuter.hh
@@ -151,7 +151,7 @@ template <int width> class kpermuter {
         <li>Given j with j == i, q[j] == x</li>
         <li>Given j with i < j < q.size(), q[j] == p[j-1] && q[j] != x</li>
         </ul> */
-    // @safe - pure bit manipulation on owned value
+    // @unsafe - uses C-style casts (value_type)
     int insert_from_back(int i) {
         int value = back();
         // increment size, leave lower slots unchanged
@@ -198,7 +198,7 @@ template <int width> class kpermuter {
         <li>Given j with i <= j < q.size(), q[j] == p[j+1]</li>
         <li>q[q.size()] == p[i]</li>
         </ul> */
-    // @safe - pure bit manipulation on owned value
+    // @unsafe - uses C-style casts (value_type)
     void remove(int i) {
         (void) width;
         if (int(x_ & 15) == i + 1)

--- a/src/mako/masstree/ksearch.hh
+++ b/src/mako/masstree/ksearch.hh
@@ -16,6 +16,7 @@
 // @safe - Key search algorithms for Masstree nodes
 // Provides linear and binary search over permuted key arrays
 // All functions perform pure computation without pointer manipulation
+// @external: { htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe], hashcode: [unsafe] }
 
 #ifndef KSEARCH_HH
 #define KSEARCH_HH 1

--- a/src/mako/masstree/ksearch.hh
+++ b/src/mako/masstree/ksearch.hh
@@ -13,9 +13,9 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe - Key search algorithms for Masstree nodes
+// @safe - Key search algorithms for Masstree nodes
 // Provides linear and binary search over permuted key arrays
-// SAFETY: Template metaprogramming with comparator-based key lookup
+// All functions perform pure computation without pointer manipulation
 
 #ifndef KSEARCH_HH
 #define KSEARCH_HH 1
@@ -23,7 +23,7 @@
 
 template <typename KA, typename T>
 struct key_comparator {
-    // @safe - delegates to n.compare_key
+    // @safe - delegates to n.compare_key which is safe
     int operator()(const KA& ka, const T& n, int p) {
         return n.compare_key(ka, p);
     }
@@ -42,7 +42,7 @@ struct key_indexed_position {
 };
 
 
-// @unsafe - calls methods on template parameters without safety guarantees
+// @unsafe - calls comparator functor which may be unsafe
 template <typename KA, typename T, typename F>
 int key_upper_bound_by(const KA& ka, const T& n, F comparator)
 {
@@ -62,14 +62,14 @@ int key_upper_bound_by(const KA& ka, const T& n, F comparator)
     return l;
 }
 
-// @unsafe - delegates to unsafe key_upper_bound_by
+// @unsafe - delegates to key_upper_bound_by which calls comparator
 template <typename KA, typename T>
 inline int key_upper_bound(const KA& ka, const T& n)
 {
     return key_upper_bound_by(ka, n, key_comparator<KA, T>());
 }
 
-// @unsafe - calls methods on template parameters without safety guarantees
+// @unsafe - checker flags return statement as having address-of
 template <typename KA, typename T, typename F>
 key_indexed_position key_lower_bound_by(const KA& ka, const T& n, F comparator)
 {
@@ -97,7 +97,7 @@ inline key_indexed_position key_lower_bound(const KA& ka, const T& n)
 }
 
 
-// @unsafe - scans raw permutations without lifetime tracking
+// @unsafe - calls comparator functor which may be unsafe
 template <typename KA, typename T, typename F>
 int key_find_upper_bound_by(const KA& ka, const T& n, F comparator)
 {
@@ -114,7 +114,7 @@ int key_find_upper_bound_by(const KA& ka, const T& n, F comparator)
     return l;
 }
 
-// @unsafe - linear search over raw key slots
+// @unsafe - checker flags return statement as having address-of
 template <typename KA, typename T, typename F>
 key_indexed_position key_find_lower_bound_by(const KA& ka, const T& n, F comparator)
 {
@@ -136,7 +136,7 @@ key_indexed_position key_find_lower_bound_by(const KA& ka, const T& n, F compara
 
 struct key_bound_binary {
     static constexpr bool is_binary = true;
-    // @unsafe - delegates to unsafe binary search
+    // @unsafe - delegates to key_upper_bound_by which calls comparator
     template <typename KA, typename T>
     static inline int upper(const KA& ka, const T& n) {
         return key_upper_bound_by(ka, n, key_comparator<KA, T>());
@@ -155,7 +155,7 @@ struct key_bound_binary {
 
 struct key_bound_linear {
     static constexpr bool is_binary = false;
-    // @unsafe - delegates to unsafe linear search
+    // @unsafe - delegates to key_find_upper_bound_by which calls comparator
     template <typename KA, typename T>
     static inline int upper(const KA& ka, const T& n) {
         return key_find_upper_bound_by(ka, n, key_comparator<KA, T>());

--- a/src/mako/masstree/kvio.cc
+++ b/src/mako/masstree/kvio.cc
@@ -1,3 +1,6 @@
+// @unsafe - Buffered I/O implementation using raw malloc and file descriptors
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2014 President and Fellows of Harvard College
@@ -13,11 +16,9 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// Buffered I/O implementation using raw malloc and file descriptors
 // All functions are @unsafe - use malloc/free and raw I/O
 //
 // @external_unsafe_type: std::*
-// @external_unsafe: std::*
 // @external_unsafe: malloc
 // @external_unsafe: free
 // @external_unsafe: read

--- a/src/mako/masstree/kvio.cc
+++ b/src/mako/masstree/kvio.cc
@@ -60,10 +60,10 @@ kvout* new_bufkvout() {
     return kv;
 }
 
-// @unsafe - dereferences raw kvout* pointer without ownership verification
-void kvout_reset(kvout* kv) {
-    assert(kv->fd < 0);
-    kv->n = 0;
+// @safe - resets buffer position, no allocation or pointer operations
+void kvout_reset(kvout& kv) {
+    assert(kv.fd < 0);
+    kv.n = 0;
 }
 
 // @unsafe - calls free() on untracked heap memory without ownership verification

--- a/src/mako/masstree/kvio.hh
+++ b/src/mako/masstree/kvio.hh
@@ -16,6 +16,7 @@
 // @unsafe - Buffered I/O structures for network communication
 // Provides kvout buffer management for serialized key-value protocol
 // SAFETY: Raw buffer allocation, file descriptor management
+// @external_unsafe: assign
 
 #ifndef KVIO_H
 #define KVIO_H
@@ -31,21 +32,27 @@ struct kvout {
     unsigned capacity; // allocated size of buf
     unsigned n;   // # of chars we've written to buf
 
-    // @unsafe - appends into raw buffer
+    // @unsafe - appends into raw buffer, calls grow() which may reallocate
     inline void append(char c);
+    // @unsafe - returns pointer into raw buffer that may be invalidated by reallocation
     inline char* reserve(int n);
+    // @safe - pure arithmetic on length field with precondition check
     inline void adjust_length(int delta);
+    // @safe - pure pointer arithmetic to update length field
     inline void set_end(char* end);
+    // @unsafe - calls realloc() which may invalidate existing pointers
     void grow(unsigned want);
 };
 
 kvout* new_kvout(int fd, int buflen);
 kvout* new_bufkvout();
-void kvout_reset(kvout* kv);
+// @safe - resets buffer position, no allocation or pointer operations
+void kvout_reset(kvout& kv);
 void free_kvout(kvout* kv);
 int kvwrite(kvout* kv, const void* buf, unsigned int n);
 void kvflush(kvout* kv);
 
+// @unsafe - may call grow() which reallocates
 inline void kvout::append(char c) {
     if (n == capacity)
         grow(0);
@@ -53,17 +60,20 @@ inline void kvout::append(char c) {
     ++n;
 }
 
+// @unsafe - returns pointer into buffer that may be invalidated
 inline char* kvout::reserve(int nchars) {
     if (n + nchars > capacity)
         grow(n + nchars);
     return buf + n;
 }
 
+// @safe - pure arithmetic with precondition check, no allocation or pointer operations
 inline void kvout::adjust_length(int delta) {
     masstree_precondition(n + delta <= capacity);
     n += delta;
 }
 
+// @safe - pure pointer arithmetic with bounds check, no allocation
 inline void kvout::set_end(char* x) {
     masstree_precondition(x >= buf && x <= buf + capacity);
     n = x - buf;

--- a/src/mako/masstree/kvio.hh
+++ b/src/mako/masstree/kvio.hh
@@ -16,7 +16,7 @@
 // @unsafe - Buffered I/O structures for network communication
 // Provides kvout buffer management for serialized key-value protocol
 // SAFETY: Raw buffer allocation, file descriptor management
-// @external_unsafe: assign
+// @external: { assign: [unsafe], htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe], hashcode: [unsafe] }
 
 #ifndef KVIO_H
 #define KVIO_H

--- a/src/mako/masstree/kvproto.hh
+++ b/src/mako/masstree/kvproto.hh
@@ -52,13 +52,14 @@ struct row_marker {
     int marker_type_;
 };
 
-// @safe - pure read-only operation on reference
+// @unsafe - overloaded functions share annotation storage (collision bug)
+// Both versions marked unsafe to avoid checker misclassification
 template <typename R>
 inline bool row_is_marker(const R& row) {
     return row.timestamp() & 1;
 }
 
-// @unsafe - pointer dereference requires unsafe context
+// @unsafe - pointer dereference delegates to reference version
 template <typename R>
 inline bool row_is_marker(const R* row) {
     return row_is_marker(*row);

--- a/src/mako/masstree/kvproto.hh
+++ b/src/mako/masstree/kvproto.hh
@@ -58,4 +58,10 @@ inline bool row_is_marker(const R& row) {
     return row.timestamp() & 1;
 }
 
+// @unsafe - pointer dereference requires unsafe context
+template <typename R>
+inline bool row_is_marker(const R* row) {
+    return row_is_marker(*row);
+}
+
 #endif

--- a/src/mako/masstree/kvproto.hh
+++ b/src/mako/masstree/kvproto.hh
@@ -13,9 +13,8 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe - Protocol constants and message type definitions
+// @safe - Protocol constants and message type definitions
 // Defines command codes and flags for key-value wire protocol
-// SAFETY: Pure constants and type definitions (no unsafe operations)
 
 #ifndef KVPROTO_HH
 #define KVPROTO_HH
@@ -53,10 +52,10 @@ struct row_marker {
     int marker_type_;
 };
 
-// @unsafe - inspects raw timestamp bits; caller must ensure row pointer is valid
+// @safe - pure read-only operation on reference
 template <typename R>
-inline bool row_is_marker(const R* row) {
-    return row->timestamp() & 1;
+inline bool row_is_marker(const R& row) {
+    return row.timestamp() & 1;
 }
 
 #endif

--- a/src/mako/masstree/kvproto.hh
+++ b/src/mako/masstree/kvproto.hh
@@ -52,17 +52,10 @@ struct row_marker {
     int marker_type_;
 };
 
-// @unsafe - overloaded functions share annotation storage (collision bug)
-// Both versions marked unsafe to avoid checker misclassification
-template <typename R>
-inline bool row_is_marker(const R& row) {
-    return row.timestamp() & 1;
-}
-
-// @unsafe - pointer dereference delegates to reference version
+// @unsafe - pointer dereference to check marker bit
 template <typename R>
 inline bool row_is_marker(const R* row) {
-    return row_is_marker(*row);
+    return row->timestamp() & 1;
 }
 
 #endif

--- a/src/mako/masstree/kvrandom.hh
+++ b/src/mako/masstree/kvrandom.hh
@@ -13,9 +13,9 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe - Random number generators for testing and benchmarking
+// @safe - Random number generators for testing and benchmarking
 // Provides PSDES, xorshift, and lcg-based generators
-// SAFETY: Pure arithmetic operations (no unsafe memory operations)
+// Pure arithmetic operations with deterministic state
 
 #ifndef KVRANDOM_HH
 #define KVRANDOM_HH 1
@@ -27,15 +27,19 @@ class kvrandom_lcg_nr_simple { public:
     enum { min_value = 0, max_value = 0xFFFFFFFFU };
     typedef uint32_t value_type;
     typedef uint32_t seed_type;
+    // @safe - default initialization
     kvrandom_lcg_nr_simple()
 	: seed_(default_seed) {
     }
+    // @safe - seed initialization
     explicit kvrandom_lcg_nr_simple(seed_type seed)
 	: seed_(seed) {
     }
+    // @safe - pure state update
     void reset(seed_type seed) {
 	seed_ = seed;
     }
+    // @safe - pure arithmetic
     value_type next() {
 	return (seed_ = seed_ * a + c);
     }
@@ -50,6 +54,7 @@ class kvrandom_lcg_nr_simple { public:
 class kvrandom_lcg_nr : public kvrandom_lcg_nr_simple { public:
     enum { min_value = 0, max_value = 0x7FFFFFFF };
     typedef int32_t value_type;
+    // @safe - pure arithmetic combining two LCG outputs
     value_type next() {
 	uint32_t x0 = kvrandom_lcg_nr_simple::next(),
 	    x1 = kvrandom_lcg_nr_simple::next();
@@ -62,23 +67,26 @@ class kvrandom_psdes_nr { public:
     enum { min_value = 0, max_value = 0xFFFFFFFFU };
     typedef uint32_t value_type;
     typedef uint32_t seed_type;
+    // @safe - default initialization
     kvrandom_psdes_nr() {
         reset(1);
     }
+    // @safe - seed initialization
     explicit kvrandom_psdes_nr(seed_type seed) {
         reset(seed);
     }
-    // @unsafe - mutates internal seed with deterministic PRNG math; no locking
+    // @safe - pure state update
     void reset(seed_type seed) {
 	seed_ = seed;
 	next_ = 1;
     }
-    // @unsafe - uses raw internal state without synchronization
+    // @safe - pure arithmetic hash function
     value_type next() {
 	uint32_t value = psdes(seed_, next_);
 	++next_;
 	return value;
     }
+    // @safe - pure hash computation
     value_type operator[](uint32_t index) const {
 	return psdes(seed_, index);
     }
@@ -87,16 +95,20 @@ class kvrandom_psdes_nr { public:
     uint32_t next_;
     enum { niter = 4 };
     static const uint32_t c1[niter], c2[niter];
+    // @safe - pure arithmetic hash
     static uint32_t psdes(uint32_t lword, uint32_t irword);
 };
 
 // a wrapper around random(), for backwards compatibility
 class kvrandom_random { public:
+    // @safe - default constructor
     kvrandom_random() {
     }
+    // @unsafe - calls external srandom()
     void reset(uint32_t seed) {
 	srandom(seed);
     }
+    // @unsafe - calls external random()
     int32_t next() const {
 	return random();
     }

--- a/src/mako/masstree/kvrow.hh
+++ b/src/mako/masstree/kvrow.hh
@@ -87,10 +87,10 @@ class query {
     lcdf::String scankey_;
     int scankeypos_;
 
-    // @unsafe - calls external String::make_stable; uses safe reference parameters
-    void emit_fields(const R& value, Json& req, threadinfo& ti);
-    // @unsafe - calls external String::make_stable; uses safe reference parameters
-    void emit_fields1(const R& value, Json& req, threadinfo& ti);
+    // @unsafe - calls external String::make_stable
+    void emit_fields(const R* value, Json& req, threadinfo& ti);
+    // @unsafe - calls external String::make_stable
+    void emit_fields1(const R* value, Json& req, threadinfo& ti);
     void assign_timestamp(threadinfo& ti);
     void assign_timestamp(threadinfo& ti, kvtimestamp_t t);
     inline bool apply_put(R*& value, bool found, const Json* firstreq,
@@ -103,10 +103,10 @@ class query {
 };
 
 
-// @unsafe - calls external String::make_stable; uses safe reference parameters
+// @unsafe - calls external String::make_stable
 template <typename R>
-void query<R>::emit_fields(const R& value, Json& req, threadinfo& ti) {
-    const R& snapshot = helper_.snapshot(value, f_, ti);
+void query<R>::emit_fields(const R* value, Json& req, threadinfo& ti) {
+    const R& snapshot = helper_.snapshot(*value, f_, ti);
     if (f_.empty()) {
         for (int i = 0; i != snapshot.ncol(); ++i)
             req.push_back(lcdf::String::make_stable(snapshot.col(i)));
@@ -116,10 +116,10 @@ void query<R>::emit_fields(const R& value, Json& req, threadinfo& ti) {
     }
 }
 
-// @unsafe - calls external String::make_stable; uses safe reference parameters
+// @unsafe - calls external String::make_stable
 template <typename R>
-void query<R>::emit_fields1(const R& value, Json& req, threadinfo& ti) {
-    const R& snapshot = helper_.snapshot(value, f_, ti);
+void query<R>::emit_fields1(const R* value, Json& req, threadinfo& ti) {
+    const R& snapshot = helper_.snapshot(*value, f_, ti);
     if ((f_.empty() && snapshot.ncol() == 1) || f_.size() == 1)
         req = lcdf::String::make_stable(snapshot.col(f_.empty() ? 0 : f_[0]));
     else if (f_.empty()) {
@@ -132,6 +132,7 @@ void query<R>::emit_fields1(const R& value, Json& req, threadinfo& ti) {
 }
 
 
+// @unsafe - calls find_unlocked and emit_fields which are unsafe
 template <typename R> template <typename T>
 void query<R>::run_get(T& table, Json& req, threadinfo& ti) {
     typename T::unlocked_cursor_type lp(table, req[2].as_s());
@@ -143,10 +144,11 @@ void query<R>::run_get(T& table, Json& req, threadinfo& ti) {
         for (int i = 3; i != req.size(); ++i)
             f_.push_back(req[i].as_i());
         req.resize(2);
-        emit_fields(*lp.value(), req, ti);
+        emit_fields(lp.value(), req, ti);
     }
 }
 
+// @unsafe - calls find_unlocked and accesses raw row pointer
 template <typename R> template <typename T>
 bool query<R>::run_get1(T& table, Str key, int col, Str& value, threadinfo& ti) {
     typename T::unlocked_cursor_type lp(table, key);
@@ -174,6 +176,7 @@ inline void query<R>::assign_timestamp(threadinfo& ti, kvtimestamp_t min_ts) {
 }
 
 
+// @unsafe - calls find_insert and apply_put which manipulate raw pointers
 template <typename R> template <typename T>
 result_t query<R>::run_put(T& table, Str key,
                            const Json* firstreq, const Json* lastreq,
@@ -218,6 +221,7 @@ inline bool query<R>::apply_put(R*& value, bool found, const Json* firstreq,
     return false;
 }
 
+// @unsafe - calls find_insert and apply_replace which manipulate raw pointers
 template <typename R> template <typename T>
 result_t query<R>::run_replace(T& table, Str key, Str value, threadinfo& ti) {
     typename T::cursor_type lp(table, key);
@@ -250,6 +254,7 @@ inline bool query<R>::apply_replace(R*& value, bool found, Str new_value,
     return inserted;
 }
 
+// @unsafe - calls find_locked and apply_remove which manipulate raw pointers
 template <typename R> template <typename T>
 bool query<R>::run_remove(T& table, Str key, threadinfo& ti) {
     typename T::cursor_type lp(table, key);
@@ -296,6 +301,7 @@ class query_json_scanner {
     template <typename SS, typename K>
     void visit_leaf(const SS&, const K&, threadinfo&) {
     }
+    // @unsafe - calls external String::make_uninitialized and emit_fields1
     bool visit_value(Str key, R* value, threadinfo& ti) {
         if (row_is_marker(value))
             return true;
@@ -309,7 +315,7 @@ class query_json_scanner {
         request_.push_back(q_.scankey_.substr(q_.scankeypos_, key.length()));
         q_.scankeypos_ += key.length();
         request_.push_back(lcdf::Json());
-        q_.emit_fields1(*value, request_.back(), ti);
+        q_.emit_fields1(value, request_.back(), ti);
         --nleft_;
         return nleft_ != 0;
     }
@@ -320,6 +326,7 @@ class query_json_scanner {
     lcdf::String firstkey_;
 };
 
+// @unsafe - calls table.scan which traverses raw tree nodes
 template <typename R> template <typename T>
 void query<R>::run_scan(T& table, Json& request, threadinfo& ti) {
     assert(request[3].as_i() > 0);
@@ -330,6 +337,7 @@ void query<R>::run_scan(T& table, Json& request, threadinfo& ti) {
     table.scan(scanf.firstkey(), true, scanf, ti);
 }
 
+// @unsafe - calls table.rscan which traverses raw tree nodes
 template <typename R> template <typename T>
 void query<R>::run_rscan(T& table, Json& request, threadinfo& ti) {
     assert(request[3].as_i() > 0);

--- a/src/mako/masstree/kvrow.hh
+++ b/src/mako/masstree/kvrow.hh
@@ -16,8 +16,7 @@
 // @unsafe - Row type management for Masstree values
 // Provides row allocation, change detection, and log replay interfaces
 // SAFETY: Uses threadinfo allocator, log callbacks, row marker sentinels
-// @external_unsafe: lcdf::String::make_stable
-// @external_unsafe: lcdf::String::make_uninitialized
+// @external: { lcdf::String::make_stable: [unsafe], lcdf::String::make_uninitialized: [unsafe], threadinfo::pthread: [unsafe] }
 
 #ifndef KVROW_HH
 #define KVROW_HH 1

--- a/src/mako/masstree/kvrow.hh
+++ b/src/mako/masstree/kvrow.hh
@@ -16,6 +16,8 @@
 // @unsafe - Row type management for Masstree values
 // Provides row allocation, change detection, and log replay interfaces
 // SAFETY: Uses threadinfo allocator, log callbacks, row marker sentinels
+// @external_unsafe: lcdf::String::make_stable
+// @external_unsafe: lcdf::String::make_uninitialized
 
 #ifndef KVROW_HH
 #define KVROW_HH 1
@@ -41,7 +43,9 @@ typedef value_bag<uint16_t> row_type;
 
 template <typename R>
 struct query_helper {
-    inline const R* snapshot(const R* row, const std::vector<typename R::index_type>&, threadinfo&) {
+    // @safe - identity function, returns input reference unchanged
+    // @lifetime: (&'a, ...) -> &'a
+    inline const R& snapshot(const R& row, const std::vector<typename R::index_type>&, threadinfo&) {
         return row;
     }
 };
@@ -71,6 +75,8 @@ class query {
     template <typename T>
     void run_rscan(T& table, Json& request, threadinfo& ti);
 
+    // @safe - returns const reference to member field, no side effects
+    // @lifetime: (&'a self) -> &'a
     const loginfo::query_times& query_times() const {
         return qtimes_;
     }
@@ -82,8 +88,10 @@ class query {
     lcdf::String scankey_;
     int scankeypos_;
 
-    void emit_fields(const R* value, Json& req, threadinfo& ti);
-    void emit_fields1(const R* value, Json& req, threadinfo& ti);
+    // @unsafe - calls external String::make_stable; uses safe reference parameters
+    void emit_fields(const R& value, Json& req, threadinfo& ti);
+    // @unsafe - calls external String::make_stable; uses safe reference parameters
+    void emit_fields1(const R& value, Json& req, threadinfo& ti);
     void assign_timestamp(threadinfo& ti);
     void assign_timestamp(threadinfo& ti, kvtimestamp_t t);
     inline bool apply_put(R*& value, bool found, const Json* firstreq,
@@ -96,29 +104,31 @@ class query {
 };
 
 
+// @unsafe - calls external String::make_stable; uses safe reference parameters
 template <typename R>
-void query<R>::emit_fields(const R* value, Json& req, threadinfo& ti) {
-    const R* snapshot = helper_.snapshot(value, f_, ti);
+void query<R>::emit_fields(const R& value, Json& req, threadinfo& ti) {
+    const R& snapshot = helper_.snapshot(value, f_, ti);
     if (f_.empty()) {
-        for (int i = 0; i != snapshot->ncol(); ++i)
-            req.push_back(lcdf::String::make_stable(snapshot->col(i)));
+        for (int i = 0; i != snapshot.ncol(); ++i)
+            req.push_back(lcdf::String::make_stable(snapshot.col(i)));
     } else {
         for (int i = 0; i != (int) f_.size(); ++i)
-            req.push_back(lcdf::String::make_stable(snapshot->col(f_[i])));
+            req.push_back(lcdf::String::make_stable(snapshot.col(f_[i])));
     }
 }
 
+// @unsafe - calls external String::make_stable; uses safe reference parameters
 template <typename R>
-void query<R>::emit_fields1(const R* value, Json& req, threadinfo& ti) {
-    const R* snapshot = helper_.snapshot(value, f_, ti);
-    if ((f_.empty() && snapshot->ncol() == 1) || f_.size() == 1)
-        req = lcdf::String::make_stable(snapshot->col(f_.empty() ? 0 : f_[0]));
+void query<R>::emit_fields1(const R& value, Json& req, threadinfo& ti) {
+    const R& snapshot = helper_.snapshot(value, f_, ti);
+    if ((f_.empty() && snapshot.ncol() == 1) || f_.size() == 1)
+        req = lcdf::String::make_stable(snapshot.col(f_.empty() ? 0 : f_[0]));
     else if (f_.empty()) {
-        for (int i = 0; i != snapshot->ncol(); ++i)
-            req.push_back(lcdf::String::make_stable(snapshot->col(i)));
+        for (int i = 0; i != snapshot.ncol(); ++i)
+            req.push_back(lcdf::String::make_stable(snapshot.col(i)));
     } else {
         for (int i = 0; i != (int) f_.size(); ++i)
-            req.push_back(lcdf::String::make_stable(snapshot->col(f_[i])));
+            req.push_back(lcdf::String::make_stable(snapshot.col(f_[i])));
     }
 }
 
@@ -134,7 +144,7 @@ void query<R>::run_get(T& table, Json& req, threadinfo& ti) {
         for (int i = 3; i != req.size(); ++i)
             f_.push_back(req[i].as_i());
         req.resize(2);
-        emit_fields(lp.value(), req, ti);
+        emit_fields(*lp.value(), req, ti);
     }
 }
 
@@ -150,12 +160,14 @@ bool query<R>::run_get1(T& table, Str key, int col, Str& value, threadinfo& ti) 
 }
 
 
+// @safe - pure assignment of timestamp values, no allocation or pointer manipulation
 template <typename R>
 inline void query<R>::assign_timestamp(threadinfo& ti) {
     qtimes_.ts = ti.update_timestamp();
     qtimes_.prev_ts = 0;
 }
 
+// @safe - pure assignment of timestamp values with minimum bound
 template <typename R>
 inline void query<R>::assign_timestamp(threadinfo& ti, kvtimestamp_t min_ts) {
     qtimes_.ts = ti.update_timestamp(min_ts);
@@ -269,15 +281,19 @@ inline void query<R>::apply_remove(R*& value, kvtimestamp_t& node_ts,
 template <typename R>
 class query_json_scanner {
   public:
+    // @safe - constructor initializes fields, uses std::swap for string exchange
     query_json_scanner(query<R> &q, lcdf::Json& request)
         : q_(q), nleft_(request[3].as_i()), request_(request) {
         std::swap(request[2].value().as_s(), firstkey_);
         request_.resize(2);
         q_.scankeypos_ = 0;
     }
+    // @safe - returns const reference to member field
+    // @lifetime: (&'a self) -> &'a
     const lcdf::String& firstkey() const {
         return firstkey_;
     }
+    // @safe - empty visitor function, no operations
     template <typename SS, typename K>
     void visit_leaf(const SS&, const K&, threadinfo&) {
     }
@@ -294,7 +310,7 @@ class query_json_scanner {
         request_.push_back(q_.scankey_.substr(q_.scankeypos_, key.length()));
         q_.scankeypos_ += key.length();
         request_.push_back(lcdf::Json());
-        q_.emit_fields1(value, request_.back(), ti);
+        q_.emit_fields1(*value, request_.back(), ti);
         --nleft_;
         return nleft_ != 0;
     }

--- a/src/mako/masstree/kvstats.hh
+++ b/src/mako/masstree/kvstats.hh
@@ -13,9 +13,8 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe - Statistics accumulator for performance measurement
+// @safe - Statistics accumulator for performance measurement
 // Computes running statistics with online algorithms
-// SAFETY: Uses realloc for sample storage in some modes
 
 #ifndef KVSTATS_HH
 #define KVSTATS_HH 1
@@ -24,9 +23,11 @@
 struct kvstats {
   double min, max, sum, sumsq;
   long count;
+  // @safe - default initialization
   kvstats()
     : min(-1), max(-1), sum(0), sumsq(0), count(0) {
   }
+  // @safe - pure arithmetic accumulator
   void add(double x) {
     if (!count || x < min)
       min = x;
@@ -37,16 +38,18 @@ struct kvstats {
     count += 1;
   }
   typedef void (kvstats::*unspecified_bool_type)(double);
+  // @safe - returns member function pointer
   operator unspecified_bool_type() const {
     return count ? &kvstats::add : 0;
   }
-  // @unsafe - uses libc sqrt and printf on raw accumulated totals
+  // @unsafe - uses libc printf (external function)
   void print_report(const char *name) const {
     if (count)
       printf("%s: n %ld, total %.0f, average %.0f, min %.0f, max %.0f, stddev %.0f\n",
 	     name, count, sum, sum / count, min, max,
 	     sqrt((sumsq - sum * sum / count) / (count - 1)));
   }
+  // @safe - pure arithmetic
   double avg() {
     if (count)
       return sum / count;

--- a/src/mako/masstree/kvtest.hh
+++ b/src/mako/masstree/kvtest.hh
@@ -16,7 +16,7 @@
 // @unsafe - Test harness framework for Masstree benchmarking
 // Provides workload generators, statistics collection, and result reporting
 // SAFETY: Uses global state, random generators, and test client interfaces
-// @external: { lcdf::String: [unsafe_type], String: [unsafe_type] }
+// @external: { lcdf::String: [unsafe_type], String: [unsafe_type], hashcode: [unsafe], threadinfo::pthread: [unsafe] }
 
 #ifndef KVTEST_HH
 #define KVTEST_HH

--- a/src/mako/masstree/kvtest.hh
+++ b/src/mako/masstree/kvtest.hh
@@ -16,6 +16,7 @@
 // @unsafe - Test harness framework for Masstree benchmarking
 // Provides workload generators, statistics collection, and result reporting
 // SAFETY: Uses global state, random generators, and test client interfaces
+// @external: { lcdf::String: [unsafe_type], String: [unsafe_type] }
 
 #ifndef KVTEST_HH
 #define KVTEST_HH

--- a/src/mako/masstree/kvthread.cc
+++ b/src/mako/masstree/kvthread.cc
@@ -53,7 +53,7 @@ inline threadinfo::threadinfo(int purpose, int index) {
     void *limbo_space = allocate(sizeof(limbo_group), memtag_limbo);
     mark(tc_limbo_slots, limbo_group::capacity);
     limbo_head_ = limbo_tail_ = new(limbo_space) limbo_group;
-    ts_ = 2;
+    ts_.set(2);  // @safe - uses Cell<T> for interior mutability
 }
 
 // @unsafe - uses placement new on raw malloc(8192) buffer without RAII

--- a/src/mako/masstree/kvthread.cc
+++ b/src/mako/masstree/kvthread.cc
@@ -16,6 +16,9 @@
 // Thread-local memory allocator and pool management
 // All functions are @unsafe - use malloc/free and pthread
 //
+// @external: {
+//   threadinfo: [unsafe_type]
+// }
 // @external_unsafe_type: std::*
 // @external_unsafe: std::*
 // @external_unsafe: circular_int::*

--- a/src/mako/masstree/kvthread.hh
+++ b/src/mako/masstree/kvthread.hh
@@ -53,9 +53,11 @@ struct limbo_group {
     int tail_;
     limbo_element e_[capacity];
     limbo_group *next_;
+    // @safe - default initialization
     limbo_group()
         : head_(0), tail_(0), next_() {
     }
+    // @unsafe - stores raw pointer without ownership tracking
     void push_back(void* ptr, memtag tag, mrcu_epoch_type epoch) {
         assert(tail_ < capacity);
         e_[tail_].ptr_ = ptr;
@@ -66,11 +68,13 @@ struct limbo_group {
 };
 
 template <int N> struct has_threadcounter {
+    // @safe - pure comparison
     static bool test(threadcounter ci) {
         return unsigned(ci) < unsigned(N);
     }
 };
 template <> struct has_threadcounter<0> {
+    // @safe - always returns false
     static bool test(threadcounter) {
         return false;
     }
@@ -82,6 +86,7 @@ struct mrcu_callback {
     virtual void operator()(threadinfo& ti) = 0;
 };
 
+// @unsafe
 class threadinfo {
   public:
     enum {
@@ -90,6 +95,7 @@ class threadinfo {
 
     // allthreads is now per-context in MasstreeContext
 
+    // @safe - returns stored pointer
     threadinfo* next() const {
         return next_;
     }
@@ -98,18 +104,23 @@ class threadinfo {
     // XXX destructor
 
     // thread information
+    // @safe - returns stored value
     int purpose() const {
         return purpose_;
     }
+    // @safe - returns stored value
     int index() const {
         return index_;
     }
+    // @safe - returns stored pointer
     MasstreeContext* context() const {
         return context_;
     }
+    // @safe - returns stored pointer
     loginfo* logger() const {
         return logger_;
     }
+    // @unsafe - asserts and modifies raw pointer
     void set_logger(loginfo* logger) {
         assert(!logger_ && logger);
         logger_ = logger;
@@ -128,23 +139,28 @@ class threadinfo {
             ts_ = (x | 1) + 1;
         return ts_;
     }
-    template <typename N> void observe_phantoms(N* n) {
-        if (circular_int<kvtimestamp_t>::less(ts_, n->phantom_epoch_[0]))
-            ts_ = n->phantom_epoch_[0];
+    // @safe - pure timestamp comparison and assignment
+    template <typename N> void observe_phantoms(const N& n) {
+        if (circular_int<kvtimestamp_t>::less(ts_, n.phantom_epoch_[0]))
+            ts_ = n.phantom_epoch_[0];
     }
 
     // event counters
+    // @safe - simple array increment
     void mark(threadcounter ci) {
         if (has_threadcounter<int(ncounters)>::test(ci))
             ++counters_[ci];
     }
+    // @safe - simple array update
     void mark(threadcounter ci, int64_t delta) {
         if (has_threadcounter<int(ncounters)>::test(ci))
             counters_[ci] += delta;
     }
+    // @safe - delegates to has_threadcounter::test
     bool has_counter(threadcounter ci) const {
         return has_threadcounter<int(ncounters)>::test(ci);
     }
+    // @safe - array access with bounds check
     uint64_t counter(threadcounter ci) const {
         return has_threadcounter<int(ncounters)>::test(ci) ? counters_[ci] : 0;
     }

--- a/src/mako/masstree/kvthread.hh
+++ b/src/mako/masstree/kvthread.hh
@@ -282,7 +282,7 @@ class threadinfo {
     }
 
     // RCU
-    // @safe - reads epoch and updates local field
+    // @unsafe - dereferences context_ pointer
     void rcu_start() {
         mrcu_epoch_type current = context_->get_epoch();
         if (gc_epoch_ != current)

--- a/src/mako/masstree/kvthread.hh
+++ b/src/mako/masstree/kvthread.hh
@@ -128,6 +128,7 @@ class threadinfo {
     }
 
     // timestamps
+    // @safe - delegates to safe timestamp()
     kvtimestamp_t operation_timestamp() const {
         return timestamp();
     }
@@ -280,30 +281,37 @@ class threadinfo {
     }
 
     // RCU
+    // @safe - reads epoch and updates local field
     void rcu_start() {
         mrcu_epoch_type current = context_->get_epoch();
         if (gc_epoch_ != current)
             gc_epoch_ = current;
     }
+    // @unsafe - may call hard_rcu_quiesce which frees memory
     void rcu_stop() {
         if (limbo_epoch_ && (gc_epoch_ - limbo_epoch_) > 1)
             hard_rcu_quiesce();
         gc_epoch_ = 0;
     }
+    // @unsafe - may call hard_rcu_quiesce which frees memory
     void rcu_quiesce() {
         rcu_start();
         if (limbo_epoch_ && (gc_epoch_ - limbo_epoch_) > 2)
             hard_rcu_quiesce();
     }
     typedef ::mrcu_callback mrcu_callback;
+    // @unsafe - delegates to unsafe record_rcu
     void rcu_register(mrcu_callback* cb) {
         record_rcu(cb, memtag(-1));
     }
 
     // thread management
+    // @safe - returns reference to stored pthread_t
+    // @lifetime: (&'a) -> &'a
     pthread_t& pthread() {
         return pthreadid_;
     }
+    // @safe - returns stored pthread_t value
     pthread_t pthread() const {
         return pthreadid_;
     }
@@ -370,10 +378,12 @@ class threadinfo {
 
 #if ENABLE_ASSERTIONS
     static int no_pool_value;
+    // @safe - returns negation of static value
     static bool use_pool() {
         return !no_pool_value;
     }
 #else
+    // @safe - always returns true
     static bool use_pool() {
         return true;
     }

--- a/src/mako/masstree/kvthread.hh
+++ b/src/mako/masstree/kvthread.hh
@@ -16,6 +16,7 @@
 // @unsafe - Thread-local state and memory allocation for Masstree
 // Provides per-thread memory pools, epoch tracking, and RCU-style reclamation
 // SAFETY: Uses malloc/mmap, pthread TLS, and epoch-based memory management
+// @external: { MasstreeContext::get_epoch: [unsafe], timestamp: [unsafe], __builtin_expect: [unsafe], hashcode: [unsafe] }
 
 #ifndef KVTHREAD_HH
 #define KVTHREAD_HH 1
@@ -306,12 +307,12 @@ class threadinfo {
     }
 
     // thread management
-    // @safe - returns reference to stored pthread_t
+    // @unsafe - returns reference to stored pthread_t (no lifetime annotation)
     // @lifetime: (&'a) -> &'a
     pthread_t& pthread() {
         return pthreadid_;
     }
-    // @safe - returns stored pthread_t value
+    // @unsafe - overload must match non-const version's annotation
     pthread_t pthread() const {
         return pthreadid_;
     }

--- a/src/mako/masstree/kvthread.hh
+++ b/src/mako/masstree/kvthread.hh
@@ -129,7 +129,7 @@ class threadinfo {
     }
 
     // timestamps
-    // @safe - delegates to safe timestamp()
+    // @unsafe - calls external timestamp() which is unsafe
     kvtimestamp_t operation_timestamp() const {
         return timestamp();
     }

--- a/src/mako/masstree/kvthread.hh
+++ b/src/mako/masstree/kvthread.hh
@@ -25,6 +25,7 @@
 #include "circular_int.hh"
 #include "timestamp.hh"
 #include "memdebug.hh"
+#include <rusty/cell.hpp>
 #include <assert.h>
 #include <pthread.h>
 #include <sys/mman.h>
@@ -130,19 +131,21 @@ class threadinfo {
     kvtimestamp_t operation_timestamp() const {
         return timestamp();
     }
+    // @safe - returns value via Cell<T>.get()
     kvtimestamp_t update_timestamp() const {
-        return ts_;
+        return ts_.get();
     }
+    // @safe - uses Cell<T> for interior mutability
     kvtimestamp_t update_timestamp(kvtimestamp_t x) const {
-        if (circular_int<kvtimestamp_t>::less_equal(ts_, x))
+        if (circular_int<kvtimestamp_t>::less_equal(ts_.get(), x))
             // x might be a marker timestamp; ensure result is not
-            ts_ = (x | 1) + 1;
-        return ts_;
+            ts_.set((x | 1) + 1);
+        return ts_.get();
     }
-    // @safe - pure timestamp comparison and assignment
+    // @safe - uses Cell<T> for interior mutability
     template <typename N> void observe_phantoms(const N& n) {
-        if (circular_int<kvtimestamp_t>::less(ts_, n.phantom_epoch_[0]))
-            ts_ = n.phantom_epoch_[0];
+        if (circular_int<kvtimestamp_t>::less(ts_.get(), n.phantom_epoch_[0]))
+            ts_.set(n.phantom_epoch_[0]);
     }
 
     // event counters
@@ -331,7 +334,7 @@ class threadinfo {
 
     limbo_group* limbo_head_;
     limbo_group* limbo_tail_;
-    mutable kvtimestamp_t ts_;
+    rusty::Cell<kvtimestamp_t> ts_;  // @safe - interior mutability via Cell<T>
 
     //enum { ncounters = (int) tc_max };
     enum { ncounters = 0 };

--- a/src/mako/masstree/kvthread.hh
+++ b/src/mako/masstree/kvthread.hh
@@ -97,7 +97,7 @@ class threadinfo {
 
     // allthreads is now per-context in MasstreeContext
 
-    // @safe - returns stored pointer
+    // @unsafe - returns raw pointer
     threadinfo* next() const {
         return next_;
     }
@@ -114,11 +114,11 @@ class threadinfo {
     int index() const {
         return index_;
     }
-    // @safe - returns stored pointer
+    // @unsafe - returns raw pointer
     MasstreeContext* context() const {
         return context_;
     }
-    // @safe - returns stored pointer
+    // @unsafe - returns raw pointer
     loginfo* logger() const {
         return logger_;
     }

--- a/src/mako/masstree/masstree.hh
+++ b/src/mako/masstree/masstree.hh
@@ -67,6 +67,7 @@ class basic_table {
     typedef unlocked_tcursor<P> unlocked_cursor_type;
     typedef tcursor<P> cursor_type;
 
+    // @safe - default initialization
     inline basic_table();
 
     // @unsafe - mutates root pointer using raw allocation
@@ -74,7 +75,9 @@ class basic_table {
     // @unsafe - tears down tree via raw pointers
     void destroy(threadinfo& ti);
 
+    // @safe - returns stored pointer
     inline node_type* root() const;
+    // @unsafe - may mutate root pointer
     inline node_type* fix_root();
 
     bool get(Str key, value_type& value, threadinfo& ti) const;

--- a/src/mako/masstree/masstree_context.cc
+++ b/src/mako/masstree/masstree_context.cc
@@ -54,7 +54,7 @@ MasstreeContext* MasstreeContext::Current() {
     return g_default_context;
 }
 
-// @unsafe - allocates with new
+// @unsafe - allocates with new, caller must manage lifetime
 MasstreeContext* MasstreeContext::Create() {
     return new MasstreeContext();
 }

--- a/src/mako/masstree/masstree_context.cc
+++ b/src/mako/masstree/masstree_context.cc
@@ -3,6 +3,11 @@
  *
  * Implementation of MasstreeContext for multi-instance support.
  */
+// MasstreeContext functions for thread-local context management
+// Most functions are @unsafe due to atomic operations and raw pointers
+//
+// @external_unsafe_type: std::*
+// @external_unsafe: std::*
 
 #include "masstree_context.h"
 #include <mutex>
@@ -17,12 +22,14 @@ std::atomic<int> MasstreeContext::s_next_context_id_{0};
 static MasstreeContext* g_default_context = nullptr;
 static std::once_flag g_default_context_init;
 
+// @unsafe - uses atomic fetch_add
 MasstreeContext::MasstreeContext()
     : context_id_(s_next_context_id_.fetch_add(1))
     , epoch_(1)
     , allthreads_(nullptr) {
 }
 
+// @unsafe - uses mutex lock and atomic store
 void MasstreeContext::register_threadinfo(threadinfo* ti) {
     std::lock_guard<std::mutex> lock(allthreads_lock_);
     // ti->next_ should already be set by the caller to point to current head
@@ -30,10 +37,12 @@ void MasstreeContext::register_threadinfo(threadinfo* ti) {
     allthreads_.store(ti, std::memory_order_release);
 }
 
+// @unsafe - writes to thread-local raw pointer
 void MasstreeContext::BindCurrentThread(MasstreeContext* ctx) {
     tl_masstree_context = ctx;
 }
 
+// @unsafe - reads thread-local pointer and uses call_once with new
 MasstreeContext* MasstreeContext::Current() {
     if (tl_masstree_context) {
         return tl_masstree_context;
@@ -45,6 +54,7 @@ MasstreeContext* MasstreeContext::Current() {
     return g_default_context;
 }
 
+// @unsafe - allocates with new
 MasstreeContext* MasstreeContext::Create() {
     return new MasstreeContext();
 }

--- a/src/mako/masstree/masstree_context.cc
+++ b/src/mako/masstree/masstree_context.cc
@@ -54,7 +54,7 @@ MasstreeContext* MasstreeContext::Current() {
     return g_default_context;
 }
 
-// @unsafe - allocates with new, caller must manage lifetime
-MasstreeContext* MasstreeContext::Create() {
-    return new MasstreeContext();
+// @safe - returns Box with clear ownership
+rusty::Box<MasstreeContext> MasstreeContext::Create() {
+    return rusty::Box<MasstreeContext>(new MasstreeContext());
 }

--- a/src/mako/masstree/masstree_context.h
+++ b/src/mako/masstree/masstree_context.h
@@ -73,7 +73,8 @@ public:
     static void BindCurrentThread(MasstreeContext* ctx);
     static MasstreeContext* Current();
 
-    // Factory
+    // @unsafe - allocates with new, caller must manage lifetime
+    // Factory - creates a new MasstreeContext (caller owns the pointer)
     static MasstreeContext* Create();
 
 private:

--- a/src/mako/masstree/masstree_context.h
+++ b/src/mako/masstree/masstree_context.h
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <mutex>
 #include <cstdint>
+#include <rusty/box.hpp>
 
 class threadinfo;
 
@@ -34,6 +35,7 @@ typedef uint64_t mrcu_epoch_type;
  */
 class MasstreeContext {
 public:
+    // @unsafe - uses atomic fetch_add for ID generation
     MasstreeContext();
     ~MasstreeContext() = default;
 
@@ -42,40 +44,47 @@ public:
     MasstreeContext& operator=(const MasstreeContext&) = delete;
 
     // Epoch management
+    // @unsafe - calls atomic load
     mrcu_epoch_type get_epoch() const {
         return epoch_.load(std::memory_order_acquire);
     }
 
+    // @unsafe - atomic store operation
     void set_epoch(mrcu_epoch_type e) {
         epoch_.store(e, std::memory_order_release);
     }
 
+    // @unsafe - atomic fetch_add operation
     void increment_epoch(mrcu_epoch_type delta = 2) {
         epoch_.fetch_add(delta, std::memory_order_acq_rel);
     }
 
+    // @unsafe - returns volatile reference, bypasses atomic safety
     // Reference for direct access (needed for some legacy code patterns)
     volatile mrcu_epoch_type& epoch_ref() {
         return reinterpret_cast<volatile mrcu_epoch_type&>(epoch_);
     }
 
     // Thread registry
+    // @unsafe - returns raw pointer
     threadinfo* get_allthreads() const {
         return allthreads_.load(std::memory_order_acquire);
     }
 
+    // @unsafe - takes raw pointer, uses mutex
     void register_threadinfo(threadinfo* ti);
 
-    // Context ID (for debugging)
+    // @safe - returns copy of int
     int id() const { return context_id_; }
 
     // Static accessors for thread binding
+    // @unsafe - stores raw pointer in thread-local
     static void BindCurrentThread(MasstreeContext* ctx);
+    // @unsafe - returns raw pointer
     static MasstreeContext* Current();
 
-    // @unsafe - allocates with new, caller must manage lifetime
-    // Factory - creates a new MasstreeContext (caller owns the pointer)
-    static MasstreeContext* Create();
+    // @safe - returns Box with clear ownership
+    static rusty::Box<MasstreeContext> Create();
 
 private:
     int context_id_;

--- a/src/mako/masstree/masstree_insert.hh
+++ b/src/mako/masstree/masstree_insert.hh
@@ -130,6 +130,7 @@ bool tcursor<P>::make_new_layer(threadinfo& ti) {
     return false;
 }
 
+// @safe - pure computation with permutation manipulation and memory fence
 template <typename P>
 void tcursor<P>::finish_insert()
 {

--- a/src/mako/masstree/masstree_insert.hh
+++ b/src/mako/masstree/masstree_insert.hh
@@ -63,6 +63,7 @@ bool tcursor<P>::find_insert(threadinfo& ti)
     return make_split(ti);
 }
 
+// @unsafe - allocates and links tree nodes under locks
 template <typename P>
 bool tcursor<P>::make_new_layer(threadinfo& ti) {
     key_type oka(n_->ksuf(kx_.p));
@@ -141,6 +142,7 @@ void tcursor<P>::finish_insert()
     n_->permutation_ = perm.value();
 }
 
+// @unsafe - delegates to unsafe finish_remove/finish_insert, unlocks node
 template <typename P>
 inline void tcursor<P>::finish(int state, threadinfo& ti)
 {
@@ -157,6 +159,7 @@ inline void tcursor<P>::finish(int state, threadinfo& ti)
     n_->unlock();
 }
 
+// @unsafe - uses locked tree traversal and applies user functor
 template <typename P> template <typename F>
 inline int basic_table<P>::modify(Str key, F& f, threadinfo& ti)
 {
@@ -171,6 +174,7 @@ inline int basic_table<P>::modify(Str key, F& f, threadinfo& ti)
     return answer;
 }
 
+// @unsafe - uses locked tree traversal with insert and applies user functor
 template <typename P> template <typename F>
 inline int basic_table<P>::modify_insert(Str key, F& f, threadinfo& ti)
 {

--- a/src/mako/masstree/masstree_insert.hh
+++ b/src/mako/masstree/masstree_insert.hh
@@ -131,7 +131,7 @@ bool tcursor<P>::make_new_layer(threadinfo& ti) {
     return false;
 }
 
-// @safe - pure computation with permutation manipulation and memory fence
+// @unsafe - dereferences n_ pointer
 template <typename P>
 void tcursor<P>::finish_insert()
 {

--- a/src/mako/masstree/masstree_key.hh
+++ b/src/mako/masstree/masstree_key.hh
@@ -188,7 +188,7 @@ class key {
         memcpy(data, s.data(), cplen);
         return cplen;
     }
-    // @safe - creates new String
+    // @unsafe - calls unsafe k.unparse()
     static String unparse_ikey(ikey_type ikey) {
         key<ikey_type> k(ikey);
         return k.unparse();

--- a/src/mako/masstree/masstree_key.hh
+++ b/src/mako/masstree/masstree_key.hh
@@ -150,7 +150,7 @@ class key {
         }
     }
 
-    // @unsafe - calls ::compare() which is @unsafe
+    // @safe - pure comparison using ::compare() and arithmetic
     int compare(ikey_type ikey, int keylenx) const {
         int cmp = ::compare(this->ikey(), ikey);
         if (cmp == 0) {
@@ -162,7 +162,7 @@ class key {
         }
         return cmp;
     }
-    // @unsafe - delegates to compare (which calls ::compare)
+    // @safe - delegates to safe compare function
     int compare(const key<I>& x) const {
         return compare(x.ikey(), x.length());
     }
@@ -211,7 +211,7 @@ class key {
     operator Str() const {
         return full_string();
     }
-    // @unsafe - uses unlikely() macro which calls __builtin_expect
+    // @safe - integer arithmetic and compiler hint
     bool increment() {
         // Return true iff wrapped.
         if (has_suffix()) {

--- a/src/mako/masstree/masstree_key.hh
+++ b/src/mako/masstree/masstree_key.hh
@@ -150,7 +150,7 @@ class key {
         }
     }
 
-    // @safe - pure comparison using ::compare() and arithmetic
+    // @unsafe - calls ::compare() which involves pointer operations
     int compare(ikey_type ikey, int keylenx) const {
         int cmp = ::compare(this->ikey(), ikey);
         if (cmp == 0) {
@@ -162,7 +162,7 @@ class key {
         }
         return cmp;
     }
-    // @safe - delegates to safe compare function
+    // @unsafe - delegates to unsafe compare function
     int compare(const key<I>& x) const {
         return compare(x.ikey(), x.length());
     }

--- a/src/mako/masstree/masstree_print.hh
+++ b/src/mako/masstree/masstree_print.hh
@@ -45,6 +45,7 @@ class value_print<unsigned char*> {
     }
 };
 
+// @unsafe - dispatches to leaf/internode print via raw pointer cast
 template <typename P>
 void node_base<P>::print(FILE *f, const char *prefix, int indent, int kdepth)
 {

--- a/src/mako/masstree/masstree_remove.hh
+++ b/src/mako/masstree/masstree_remove.hh
@@ -193,7 +193,7 @@ bool tcursor<P>::remove_leaf(leaf_type& leaf, node_type* root,
     }
 
     // Unlink leaf from doubly-linked leaf list
-    btree_leaflink<leaf_type>::unlink(&leaf);
+    btree_leaflink<leaf_type>::unlink(leaf);
 
     // Remove leaf from tree. This is simple unless the leaf is the first
     // child of its parent, in which case we need to traverse up until we find

--- a/src/mako/masstree/masstree_remove.hh
+++ b/src/mako/masstree/masstree_remove.hh
@@ -302,7 +302,7 @@ struct destroy_rcu_callback : public P::threadinfo_type::mrcu_callback {
     static inline void enqueue(node_base<P>* n, node_base<P>**& tailp);
 };
 
-// @safe - pure pointer arithmetic based on node type
+// @unsafe - takes raw pointer, returns pointer-to-pointer, does pointer cast
 template <typename P>
 inline node_base<P>** destroy_rcu_callback<P>::link_ptr(node_base<P>* n) {
     if (n->isleaf())
@@ -311,7 +311,7 @@ inline node_base<P>** destroy_rcu_callback<P>::link_ptr(node_base<P>* n) {
         return &static_cast<internode_type*>(n)->parent_;
 }
 
-// @safe - simple pointer assignment for queue management
+// @unsafe - takes raw pointer, writes through pointer
 template <typename P>
 inline void destroy_rcu_callback<P>::enqueue(node_base<P>* n,
                                              node_base<P>**& tailp) {

--- a/src/mako/masstree/masstree_remove.hh
+++ b/src/mako/masstree/masstree_remove.hh
@@ -302,6 +302,7 @@ struct destroy_rcu_callback : public P::threadinfo_type::mrcu_callback {
     static inline void enqueue(node_base<P>* n, node_base<P>**& tailp);
 };
 
+// @safe - pure pointer arithmetic based on node type
 template <typename P>
 inline node_base<P>** destroy_rcu_callback<P>::link_ptr(node_base<P>* n) {
     if (n->isleaf())
@@ -310,6 +311,7 @@ inline node_base<P>** destroy_rcu_callback<P>::link_ptr(node_base<P>* n) {
         return &static_cast<internode_type*>(n)->parent_;
 }
 
+// @safe - simple pointer assignment for queue management
 template <typename P>
 inline void destroy_rcu_callback<P>::enqueue(node_base<P>* n,
                                              node_base<P>**& tailp) {

--- a/src/mako/masstree/masstree_remove.hh
+++ b/src/mako/masstree/masstree_remove.hh
@@ -161,34 +161,34 @@ bool tcursor<P>::finish_remove(threadinfo& ti)
     if (perm.size())
         return false;
     else
-        return remove_leaf(*n_, root_, ka_.prefix_string(), ti);
+        return remove_leaf(n_, root_, ka_.prefix_string(), ti);
 }
 
 template <typename P>
 // @unsafe - uses RCU, atomic CAS, and fences for node removal
-bool tcursor<P>::remove_leaf(leaf_type& leaf, node_type* root,
+bool tcursor<P>::remove_leaf(leaf_type* leaf, node_type* root,
                              Str prefix, threadinfo& ti)
 {
-    if (!leaf.prev_) {
-        if (!leaf.next_.ptr && !prefix.empty())
+    if (!leaf->prev_) {
+        if (!leaf->next_.ptr && !prefix.empty())
             gc_layer_rcu_callback<P>::make(root, prefix, ti);
         return false;
     }
 
     // mark leaf deleted, RCU-free
-    leaf.mark_deleted();
-    leaf.deallocate_rcu(ti);
+    leaf->mark_deleted();
+    leaf->deallocate_rcu(ti);
 
     // Ensure node that becomes responsible for our keys has its phantom epoch
     // kept up to date
     while (P::need_phantom_epoch) {
-        leaf_type *prev = leaf.prev_;
+        leaf_type *prev = leaf->prev_;
         typename P::phantom_epoch_type prev_ts = prev->phantom_epoch();
-        while (circular_int<typename P::phantom_epoch_type>::less(prev_ts, leaf.phantom_epoch())
-               && !bool_cmpxchg(&prev->phantom_epoch_[0], prev_ts, leaf.phantom_epoch()))
+        while (circular_int<typename P::phantom_epoch_type>::less(prev_ts, leaf->phantom_epoch())
+               && !bool_cmpxchg(&prev->phantom_epoch_[0], prev_ts, leaf->phantom_epoch()))
             prev_ts = prev->phantom_epoch();
         fence();
-        if (prev == leaf.prev_)
+        if (prev == leaf->prev_)
             break;
     }
 
@@ -198,8 +198,8 @@ bool tcursor<P>::remove_leaf(leaf_type& leaf, node_type* root,
     // Remove leaf from tree. This is simple unless the leaf is the first
     // child of its parent, in which case we need to traverse up until we find
     // its key.
-    node_type *n = &leaf;
-    ikey_type ikey = leaf.ikey_bound();
+    node_type *n = leaf;
+    ikey_type ikey = leaf->ikey_bound();
 
     while (1) {
         internode_type *p = n->locked_parent(ti);

--- a/src/mako/masstree/masstree_remove.hh
+++ b/src/mako/masstree/masstree_remove.hh
@@ -161,44 +161,45 @@ bool tcursor<P>::finish_remove(threadinfo& ti)
     if (perm.size())
         return false;
     else
-        return remove_leaf(n_, root_, ka_.prefix_string(), ti);
+        return remove_leaf(*n_, root_, ka_.prefix_string(), ti);
 }
 
 template <typename P>
-bool tcursor<P>::remove_leaf(leaf_type* leaf, node_type* root,
+// @unsafe - uses RCU, atomic CAS, and fences for node removal
+bool tcursor<P>::remove_leaf(leaf_type& leaf, node_type* root,
                              Str prefix, threadinfo& ti)
 {
-    if (!leaf->prev_) {
-        if (!leaf->next_.ptr && !prefix.empty())
+    if (!leaf.prev_) {
+        if (!leaf.next_.ptr && !prefix.empty())
             gc_layer_rcu_callback<P>::make(root, prefix, ti);
         return false;
     }
 
     // mark leaf deleted, RCU-free
-    leaf->mark_deleted();
-    leaf->deallocate_rcu(ti);
+    leaf.mark_deleted();
+    leaf.deallocate_rcu(ti);
 
     // Ensure node that becomes responsible for our keys has its phantom epoch
     // kept up to date
     while (P::need_phantom_epoch) {
-        leaf_type *prev = leaf->prev_;
+        leaf_type *prev = leaf.prev_;
         typename P::phantom_epoch_type prev_ts = prev->phantom_epoch();
-        while (circular_int<typename P::phantom_epoch_type>::less(prev_ts, leaf->phantom_epoch())
-               && !bool_cmpxchg(&prev->phantom_epoch_[0], prev_ts, leaf->phantom_epoch()))
+        while (circular_int<typename P::phantom_epoch_type>::less(prev_ts, leaf.phantom_epoch())
+               && !bool_cmpxchg(&prev->phantom_epoch_[0], prev_ts, leaf.phantom_epoch()))
             prev_ts = prev->phantom_epoch();
         fence();
-        if (prev == leaf->prev_)
+        if (prev == leaf.prev_)
             break;
     }
 
     // Unlink leaf from doubly-linked leaf list
-    btree_leaflink<leaf_type>::unlink(leaf);
+    btree_leaflink<leaf_type>::unlink(&leaf);
 
     // Remove leaf from tree. This is simple unless the leaf is the first
     // child of its parent, in which case we need to traverse up until we find
     // its key.
-    node_type *n = leaf;
-    ikey_type ikey = leaf->ikey_bound();
+    node_type *n = &leaf;
+    ikey_type ikey = leaf.ikey_bound();
 
     while (1) {
         internode_type *p = n->locked_parent(ti);

--- a/src/mako/masstree/masstree_scan.hh
+++ b/src/mako/masstree/masstree_scan.hh
@@ -21,6 +21,7 @@
 #define MASSTREE_SCAN_HH
 #include "masstree_tcursor.hh"
 #include "masstree_struct.hh"
+#include <rusty/cell.hpp>
 namespace Masstree {
 
 template <typename P>
@@ -35,18 +36,23 @@ class scanstackelt {
     typedef typename P::threadinfo_type threadinfo;
     typedef typename node_base<P>::nodeversion_type nodeversion_type;
 
+    // @safe - returns stored pointer
     leaf<P>* node() const {
         return n_;
     }
+    // @safe - pure arithmetic
     typename nodeversion_type::value_type full_version_value() const {
         return (v_.version_value() << permuter_type::size_bits) + perm_.size();
     }
+    // @safe - returns stored value
     int size() const {
         return perm_.size();
     }
+    // @safe - returns stored value
     permuter_type permutation() const {
         return perm_;
     }
+    // @unsafe - calls compare_key which may involve pointer operations
     int operator()(const key_type &k, const scanstackelt<P> &n, int p) {
         return n.n_->compare_key(k, p);
     }
@@ -86,34 +92,43 @@ class scanstackelt {
 };
 
 struct forward_scan_helper {
+    // @safe - pure comparison
     bool initial_ksuf_match(int ksuf_compare, bool emit_equal) const {
         return ksuf_compare > 0 || (ksuf_compare == 0 && emit_equal);
     }
+    // @safe - pure comparison
     template <typename K> bool is_duplicate(const K &k,
                                             typename K::ikey_type ikey,
                                             int keylenx) const {
         return k.compare(ikey, keylenx) >= 0;
     }
-    template <typename K, typename N> int lower(const K &k, const N *n) const {
-        return N::bound_type::lower_by(k, *n, *n).i;
+    // @safe - pure computation on references
+    template <typename K, typename N> int lower(const K &k, const N &n) const {
+        return N::bound_type::lower_by(k, n, n).i;
     }
+    // @safe - pure computation on references
     template <typename K, typename N>
-    key_indexed_position lower_with_position(const K &k, const N *n) const {
-        return N::bound_type::lower_by(k, *n, *n);
+    key_indexed_position lower_with_position(const K &k, const N &n) const {
+        return N::bound_type::lower_by(k, n, n);
     }
+    // @safe - no-op
     void found() const {
     }
+    // @safe - pure arithmetic
     int next(int ki) const {
         return ki + 1;
     }
+    // @unsafe - traverses via raw node pointer
     template <typename N, typename K>
     N *advance(const N *n, const K &) const {
         return n->safe_next();
     }
+    // @unsafe - calls stable() on raw node
     template <typename N, typename K>
     typename N::nodeversion_type stable(const N *n, const K &) const {
         return n->stable();
     }
+    // @safe - modifies key state
     template <typename K> void shift_clear(K &ka) const {
         ka.shift_clear();
     }
@@ -128,41 +143,50 @@ struct reverse_scan_helper {
     // The "backwards" ki must be calculated using the size taken by the
     // lower_bound, NOT some later size() (which might be bigger or smaller).
     // The helper type reverse_scan_node allows this.
+    // @safe - default initialization with Cell<bool>
     reverse_scan_helper()
-        : upper_bound_(false) {
+        : upper_bound_(false) {  // Cell<bool> constructor takes bool value
     }
+    // @safe - pure comparison
     bool initial_ksuf_match(int ksuf_compare, bool emit_equal) const {
         return ksuf_compare < 0 || (ksuf_compare == 0 && emit_equal);
     }
+    // @unsafe - k.compare() involves pointer operations; Cell<bool> for interior mutability
     template <typename K> bool is_duplicate(const K &k,
                                             typename K::ikey_type ikey,
                                             int keylenx) const {
-        return k.compare(ikey, keylenx) <= 0 && !upper_bound_;
+        return k.compare(ikey, keylenx) <= 0 && !upper_bound_.get();
     }
-    template <typename K, typename N> int lower(const K &k, const N *n) const {
-        if (upper_bound_)
-            return n->size() - 1;
-        key_indexed_position kx = N::bound_type::lower_by(k, *n, *n);
+    // @safe - pure computation on references, uses Cell<bool>
+    template <typename K, typename N> int lower(const K &k, const N &n) const {
+        if (upper_bound_.get())
+            return n.size() - 1;
+        key_indexed_position kx = N::bound_type::lower_by(k, n, n);
         return kx.i - (kx.p < 0);
     }
+    // @safe - pure computation on references
     template <typename K, typename N>
-    key_indexed_position lower_with_position(const K &k, const N *n) const {
-        key_indexed_position kx = N::bound_type::lower_by(k, *n, *n);
+    key_indexed_position lower_with_position(const K &k, const N &n) const {
+        key_indexed_position kx = N::bound_type::lower_by(k, n, n);
         kx.i -= kx.p < 0;
         return kx;
     }
+    // @safe - pure arithmetic
     int next(int ki) const {
         return ki - 1;
     }
+    // @safe - modifies internal state via Cell<bool>
     void found() const {
-        upper_bound_ = false;
+        upper_bound_.set(false);
     }
+    // @unsafe - accesses raw node members and returns raw pointer
     template <typename N, typename K>
     N *advance(const N *n, K &k) const {
         k.assign_store_ikey(n->ikey_bound());
         k.assign_store_length(0);
         return n->prev_;
     }
+    // @unsafe - traverses via raw node pointers
     template <typename N, typename K>
     typename N::nodeversion_type stable(N *&n, const K &k) const {
         while (1) {
@@ -176,12 +200,13 @@ struct reverse_scan_helper {
             n = next;
         }
     }
+    // @safe - modifies key state via Cell<bool>
     template <typename K> void shift_clear(K &ka) const {
         ka.shift_clear_reverse();
-        upper_bound_ = true;
+        upper_bound_.set(true);
     }
   private:
-    mutable bool upper_bound_;
+    rusty::Cell<bool> upper_bound_;  // @safe - interior mutability via Cell<T>
 };
 
 
@@ -203,7 +228,7 @@ int scanstackelt<P>::find_initial(H& helper, key_type& ka, bool emit_equal,
     n_->prefetch();
     perm_ = n_->permutation();
 
-    kx = helper.lower_with_position(ka, this);
+    kx = helper.lower_with_position(ka, *this);
     if (kx.p >= 0) {
         keylenx = n_->keylenx_[kx.p];
         fence();
@@ -253,7 +278,7 @@ int scanstackelt<P>::find_retry(H& helper, key_type& ka, threadinfo& ti)
 
     n_->prefetch();
     perm_ = n_->permutation();
-    ki_ = helper.lower(ka, this);
+    ki_ = helper.lower(ka, *this);
     return scan_find_next;
 }
 
@@ -308,7 +333,7 @@ int scanstackelt<P>::find_next(H &helper, key_type &ka, leafvalue_type &entry)
  changed:
     v_ = helper.stable(n_, ka);
     perm_ = n_->permutation();
-    ki_ = helper.lower(ka, this);
+    ki_ = helper.lower(ka, *this);
     return scan_find_next;
 }
 
@@ -374,7 +399,7 @@ int basic_table<P>::scan(H helper,
             } while (unlikely(ka.empty()));
             stack.v_ = helper.stable(stack.n_, ka);
             stack.perm_ = stack.n_->permutation();
-            stack.ki_ = helper.lower(ka, &stack);
+            stack.ki_ = helper.lower(ka, stack);
             goto find_next;
 
         case mystack_type::scan_down:

--- a/src/mako/masstree/masstree_split.hh
+++ b/src/mako/masstree/masstree_split.hh
@@ -23,6 +23,7 @@
 #include "btree_leaflink.hh"
 namespace Masstree {
 
+// @safe - pure computation with array access and safe accessors
 /** @brief Return ikey at position @a i, assuming insert of @a ka at @a ka_i. */
 template <typename P>
 inline typename P::ikey_type
@@ -51,8 +52,8 @@ leaf<P>::ikey_after_insert(const permuter_type& perm, int i,
     *@a nr, and 2 for the sequential-order optimization (@a ka went into *@a
     nr and no other keys were moved). */
 template <typename P>
-// @unsafe - splits leaf nodes via raw pointer shuffling
-int leaf<P>::split_into(leaf<P>* nr, int p, const key_type& ka,
+// @unsafe - uses address-of on nr reference for btree_leaflink call
+int leaf<P>::split_into(leaf<P>& nr, int p, const key_type& ka,
                         ikey_type& split_ikey, threadinfo& ti)
 {
     // B+tree leaf insertion.
@@ -64,7 +65,7 @@ int leaf<P>::split_into(leaf<P>* nr, int p, const key_type& ka,
     // If p < mid, then x goes into *this, and the first element of nr
     //   will be former item (mid - 1).
     // If p >= mid, then x goes into nr.
-    masstree_precondition(!this->concurrent || (this->locked() && nr->locked()));
+    masstree_precondition(!this->concurrent || (this->locked() && nr.locked()));
     masstree_precondition(this->size() >= this->width - 1);
 
     int width = this->size();   // == this->width or this->width - 1
@@ -97,26 +98,26 @@ int leaf<P>::split_into(leaf<P>* nr, int p, const key_type& ka,
     typename permuter_type::value_type pv = perml.value_from(mid - (p < mid));
     for (int x = mid; x <= width; ++x)
         if (x == p)
-            nr->assign_initialize(x - mid, ka, ti);
+            nr.assign_initialize(x - mid, ka, ti);
         else {
-            nr->assign_initialize(x - mid, this, pv & 15, ti);
+            nr.assign_initialize(x - mid, *this, pv & 15, ti);
             pv >>= 4;
         }
     permuter_type permr = permuter_type::make_sorted(width + 1 - mid);
     if (p >= mid)
         permr.remove_to_back(p - mid);
-    nr->permutation_ = permr.value();
+    nr.permutation_ = permr.value();
 
-    btree_leaflink<leaf<P>, P::concurrent>::link_split(this, nr);
+    btree_leaflink<leaf<P>, P::concurrent>::link_split(this, &nr);
 
-    split_ikey = nr->ikey0_[0];
+    split_ikey = nr.ikey0_[0];
     return p >= mid ? 1 + (mid == width) : 0;
 }
 
 template <typename P>
-// @unsafe - splits internode using direct memory copies
-int internode<P>::split_into(internode<P> *nr, int p, ikey_type ka,
-                             node_base<P> *value, ikey_type& split_ikey,
+// @unsafe - calls mark_split() which uses memory fences
+int internode<P>::split_into(internode<P>& nr, int p, ikey_type ka,
+                             node_base<P>* value, ikey_type& split_ikey,
                              int split_type)
 {
     // B+tree internal node insertion.
@@ -133,29 +134,29 @@ int internode<P>::split_into(internode<P> *nr, int p, ikey_type ka,
     //   nr is pre-insertion item mid.
     // If p > mid, then x goes into nr, pre-insertion item mid goes into
     //   split_ikey, and the first element of nr is post-insertion item mid+1.
-    masstree_precondition(!this->concurrent || (this->locked() && nr->locked()));
+    masstree_precondition(!this->concurrent || (this->locked() && nr.locked()));
 
     int mid = (split_type == 2 ? this->width : (this->width + 1) / 2);
-    nr->nkeys_ = this->width + 1 - (mid + 1);
+    nr.nkeys_ = this->width + 1 - (mid + 1);
 
     if (p < mid) {
-        nr->child_[0] = this->child_[mid];
-        nr->shift_from(0, this, mid, this->width - mid);
+        nr.child_[0] = this->child_[mid];
+        nr.shift_from(0, *this, mid, this->width - mid);
         split_ikey = this->ikey0_[mid - 1];
     } else if (p == mid) {
-        nr->child_[0] = value;
-        nr->shift_from(0, this, mid, this->width - mid);
+        nr.child_[0] = value;
+        nr.shift_from(0, *this, mid, this->width - mid);
         split_ikey = ka;
     } else {
-        nr->child_[0] = this->child_[mid + 1];
-        nr->shift_from(0, this, mid + 1, p - (mid + 1));
-        nr->assign(p - (mid + 1), ka, value);
-        nr->shift_from(p + 1 - (mid + 1), this, p, this->width - p);
+        nr.child_[0] = this->child_[mid + 1];
+        nr.shift_from(0, *this, mid + 1, p - (mid + 1));
+        nr.assign(p - (mid + 1), ka, *value);
+        nr.shift_from(p + 1 - (mid + 1), *this, p, this->width - p);
         split_ikey = this->ikey0_[mid];
     }
 
-    for (int i = 0; i <= nr->nkeys_; ++i)
-        nr->child_[i]->set_parent(nr);
+    for (int i = 0; i <= nr.nkeys_; ++i)
+        nr.child_[i]->set_parent(&nr);
 
     this->mark_split();
     if (p < mid) {
@@ -191,7 +192,7 @@ bool tcursor<P>::make_split(threadinfo& ti)
     node_type* child = leaf_type::make(n_->ksuf_used_capacity(), n_->phantom_epoch(), ti);
     child->assign_version(*n_);
     ikey_type xikey[2];
-    int split_type = n_->split_into(static_cast<leaf_type *>(child),
+    int split_type = n_->split_into(*static_cast<leaf_type *>(child),
                                     kx_.i, ka_, xikey[0], ti);
     bool sense = false;
 
@@ -204,7 +205,7 @@ bool tcursor<P>::make_split(threadinfo& ti)
         if (!n->parent_exists(p)) {
             internode_type *nn = internode_type::make(ti);
             nn->child_[0] = n;
-            nn->assign(0, xikey[sense], child);
+            nn->assign(0, xikey[sense], *child);
             nn->nkeys_ = 1;
             nn->make_layer_root();
             fence();
@@ -218,13 +219,13 @@ bool tcursor<P>::make_split(threadinfo& ti)
                 next_child = internode_type::make(ti);
                 next_child->assign_version(*p);
                 next_child->mark_nonroot();
-                kp = p->split_into(next_child, kp, xikey[sense],
+                kp = p->split_into(*next_child, kp, xikey[sense],
                                    child, xikey[!sense], split_type);
             }
 
             if (kp >= 0) {
                 p->shift_up(kp + 1, kp, p->size() - kp);
-                p->assign(kp, xikey[sense], child);
+                p->assign(kp, xikey[sense], *child);
                 fence();
                 ++p->nkeys_;
             }

--- a/src/mako/masstree/masstree_split.hh
+++ b/src/mako/masstree/masstree_split.hh
@@ -51,8 +51,8 @@ leaf<P>::ikey_after_insert(const permuter_type& perm, int i,
     The split type is 0 if @a ka went into *this, 1 if the @a ka went into
     *@a nr, and 2 for the sequential-order optimization (@a ka went into *@a
     nr and no other keys were moved). */
-template <typename P>
 // @unsafe - uses address-of on nr reference for btree_leaflink call
+template <typename P>
 int leaf<P>::split_into(leaf<P>& nr, int p, const key_type& ka,
                         ikey_type& split_ikey, threadinfo& ti)
 {

--- a/src/mako/masstree/masstree_split.hh
+++ b/src/mako/masstree/masstree_split.hh
@@ -51,9 +51,9 @@ leaf<P>::ikey_after_insert(const permuter_type& perm, int i,
     The split type is 0 if @a ka went into *this, 1 if the @a ka went into
     *@a nr, and 2 for the sequential-order optimization (@a ka went into *@a
     nr and no other keys were moved). */
-// @unsafe - uses address-of on nr reference for btree_leaflink call
 template <typename P>
-int leaf<P>::split_into(leaf<P>& nr, int p, const key_type& ka,
+// @unsafe - splits leaf nodes via raw pointer shuffling
+int leaf<P>::split_into(leaf<P>* nr, int p, const key_type& ka,
                         ikey_type& split_ikey, threadinfo& ti)
 {
     // B+tree leaf insertion.
@@ -65,7 +65,7 @@ int leaf<P>::split_into(leaf<P>& nr, int p, const key_type& ka,
     // If p < mid, then x goes into *this, and the first element of nr
     //   will be former item (mid - 1).
     // If p >= mid, then x goes into nr.
-    masstree_precondition(!this->concurrent || (this->locked() && nr.locked()));
+    masstree_precondition(!this->concurrent || (this->locked() && nr->locked()));
     masstree_precondition(this->size() >= this->width - 1);
 
     int width = this->size();   // == this->width or this->width - 1
@@ -98,25 +98,25 @@ int leaf<P>::split_into(leaf<P>& nr, int p, const key_type& ka,
     typename permuter_type::value_type pv = perml.value_from(mid - (p < mid));
     for (int x = mid; x <= width; ++x)
         if (x == p)
-            nr.assign_initialize(x - mid, ka, ti);
+            nr->assign_initialize(x - mid, ka, ti);
         else {
-            nr.assign_initialize(x - mid, *this, pv & 15, ti);
+            nr->assign_initialize(x - mid, *this, pv & 15, ti);
             pv >>= 4;
         }
     permuter_type permr = permuter_type::make_sorted(width + 1 - mid);
     if (p >= mid)
         permr.remove_to_back(p - mid);
-    nr.permutation_ = permr.value();
+    nr->permutation_ = permr.value();
 
-    btree_leaflink<leaf<P>, P::concurrent>::link_split(*this, nr);
+    btree_leaflink<leaf<P>, P::concurrent>::link_split(this, nr);
 
-    split_ikey = nr.ikey0_[0];
+    split_ikey = nr->ikey0_[0];
     return p >= mid ? 1 + (mid == width) : 0;
 }
 
 template <typename P>
-// @unsafe - calls mark_split() which uses memory fences
-int internode<P>::split_into(internode<P>& nr, int p, ikey_type ka,
+// @unsafe - splits internode using direct memory copies
+int internode<P>::split_into(internode<P>* nr, int p, ikey_type ka,
                              node_base<P>* value, ikey_type& split_ikey,
                              int split_type)
 {
@@ -134,29 +134,29 @@ int internode<P>::split_into(internode<P>& nr, int p, ikey_type ka,
     //   nr is pre-insertion item mid.
     // If p > mid, then x goes into nr, pre-insertion item mid goes into
     //   split_ikey, and the first element of nr is post-insertion item mid+1.
-    masstree_precondition(!this->concurrent || (this->locked() && nr.locked()));
+    masstree_precondition(!this->concurrent || (this->locked() && nr->locked()));
 
     int mid = (split_type == 2 ? this->width : (this->width + 1) / 2);
-    nr.nkeys_ = this->width + 1 - (mid + 1);
+    nr->nkeys_ = this->width + 1 - (mid + 1);
 
     if (p < mid) {
-        nr.child_[0] = this->child_[mid];
-        nr.shift_from(0, *this, mid, this->width - mid);
+        nr->child_[0] = this->child_[mid];
+        nr->shift_from(0, this, mid, this->width - mid);
         split_ikey = this->ikey0_[mid - 1];
     } else if (p == mid) {
-        nr.child_[0] = value;
-        nr.shift_from(0, *this, mid, this->width - mid);
+        nr->child_[0] = value;
+        nr->shift_from(0, this, mid, this->width - mid);
         split_ikey = ka;
     } else {
-        nr.child_[0] = this->child_[mid + 1];
-        nr.shift_from(0, *this, mid + 1, p - (mid + 1));
-        nr.assign(p - (mid + 1), ka, *value);
-        nr.shift_from(p + 1 - (mid + 1), *this, p, this->width - p);
+        nr->child_[0] = this->child_[mid + 1];
+        nr->shift_from(0, this, mid + 1, p - (mid + 1));
+        nr->assign(p - (mid + 1), ka, value);
+        nr->shift_from(p + 1 - (mid + 1), this, p, this->width - p);
         split_ikey = this->ikey0_[mid];
     }
 
-    for (int i = 0; i <= nr.nkeys_; ++i)
-        nr.child_[i]->set_parent(&nr);
+    for (int i = 0; i <= nr->nkeys_; ++i)
+        nr->child_[i]->set_parent(nr);
 
     this->mark_split();
     if (p < mid) {
@@ -192,7 +192,7 @@ bool tcursor<P>::make_split(threadinfo& ti)
     node_type* child = leaf_type::make(n_->ksuf_used_capacity(), n_->phantom_epoch(), ti);
     child->assign_version(*n_);
     ikey_type xikey[2];
-    int split_type = n_->split_into(*static_cast<leaf_type *>(child),
+    int split_type = n_->split_into(static_cast<leaf_type*>(child),
                                     kx_.i, ka_, xikey[0], ti);
     bool sense = false;
 
@@ -205,7 +205,7 @@ bool tcursor<P>::make_split(threadinfo& ti)
         if (!n->parent_exists(p)) {
             internode_type *nn = internode_type::make(ti);
             nn->child_[0] = n;
-            nn->assign(0, xikey[sense], *child);
+            nn->assign(0, xikey[sense], child);
             nn->nkeys_ = 1;
             nn->make_layer_root();
             fence();
@@ -219,13 +219,13 @@ bool tcursor<P>::make_split(threadinfo& ti)
                 next_child = internode_type::make(ti);
                 next_child->assign_version(*p);
                 next_child->mark_nonroot();
-                kp = p->split_into(*next_child, kp, xikey[sense],
+                kp = p->split_into(next_child, kp, xikey[sense],
                                    child, xikey[!sense], split_type);
             }
 
             if (kp >= 0) {
                 p->shift_up(kp + 1, kp, p->size() - kp);
-                p->assign(kp, xikey[sense], *child);
+                p->assign(kp, xikey[sense], child);
                 fence();
                 ++p->nkeys_;
             }

--- a/src/mako/masstree/masstree_split.hh
+++ b/src/mako/masstree/masstree_split.hh
@@ -108,7 +108,7 @@ int leaf<P>::split_into(leaf<P>& nr, int p, const key_type& ka,
         permr.remove_to_back(p - mid);
     nr.permutation_ = permr.value();
 
-    btree_leaflink<leaf<P>, P::concurrent>::link_split(this, &nr);
+    btree_leaflink<leaf<P>, P::concurrent>::link_split(*this, nr);
 
     split_ikey = nr.ikey0_[0];
     return p >= mid ? 1 + (mid == width) : 0;

--- a/src/mako/masstree/masstree_struct.hh
+++ b/src/mako/masstree/masstree_struct.hh
@@ -61,7 +61,7 @@ class node_base : public make_nodeversion<P>::type {
         : nodeversion_type(isleaf) {
     }
 
-    // @safe - returns parent pointer
+    // @unsafe - returns raw pointer, dereferences this
     inline base_type* parent() const {
         // almost always an internode
         if (this->isleaf())
@@ -73,13 +73,13 @@ class node_base : public make_nodeversion<P>::type {
     inline bool parent_exists(base_type* p) const {
         return p != 0;
     }
-    // @safe - delegates to parent() and parent_exists()
+    // @unsafe - calls unsafe parent()
     inline bool has_parent() const {
         return parent_exists(parent());
     }
     // @unsafe - manipulates parent pointers under locks
     inline internode_type* locked_parent(threadinfo& ti) const;
-    // @safe - sets parent pointer
+    // @unsafe - takes raw pointer, writes through this
     inline void set_parent(base_type* p) {
         if (this->isleaf())
             static_cast<leaf_type*>(this)->parent_ = p;
@@ -91,7 +91,7 @@ class node_base : public make_nodeversion<P>::type {
         set_parent(nullptr);
         this->mark_root();
     }
-    // @safe - returns parent or self
+    // @unsafe - returns raw pointer, calls unsafe parent()
     inline base_type* maybe_parent() const {
         base_type* x = parent();
         return parent_exists(x) ? x : const_cast<base_type*>(this);

--- a/src/mako/masstree/masstree_struct.hh
+++ b/src/mako/masstree/masstree_struct.hh
@@ -155,11 +155,11 @@ class internode : public node_base<P> {
     ikey_type ikey(int p) const {
         return ikey0_[p];
     }
-    // @safe - pure comparison of keys
+    // @unsafe - calls ::compare which uses template instantiation
     int compare_key(ikey_type a, int bp) const {
         return ::compare(a, ikey(bp));
     }
-    // @safe - pure comparison of keys
+    // @unsafe - calls ::compare which uses template instantiation
     int compare_key(const key_type& a, int bp) const {
         return ::compare(a.ikey(), ikey(bp));
     }
@@ -439,21 +439,21 @@ class leaf : public node_base<P> {
     bool has_ksuf(int p) const {
         return keylenx_has_ksuf(keylenx_[p]);
     }
-    // @safe - returns suffix string view
+    // @unsafe - returns suffix string view, calls stringbag::get
     Str ksuf(int p, int keylenx) const {
         (void) keylenx;
         masstree_precondition(keylenx_has_ksuf(keylenx));
         return ksuf_ ? ksuf_->get(p) : iksuf_[0].get(p);
     }
-    // @safe - returns suffix string view
+    // @unsafe - returns suffix string view, calls ksuf overload
     Str ksuf(int p) const {
         return ksuf(p, keylenx_[p]);
     }
-    // @safe - suffix comparison
+    // @unsafe - suffix comparison, calls ksuf_equals overload
     bool ksuf_equals(int p, const key_type& ka) const {
         return ksuf_equals(p, ka, keylenx_[p]);
     }
-    // @safe - suffix comparison
+    // @unsafe - suffix comparison, calls ksuf and string_slice::equals_sloppy
     bool ksuf_equals(int p, const key_type& ka, int keylenx) const {
         if (!keylenx_has_ksuf(keylenx))
             return true;
@@ -461,7 +461,7 @@ class leaf : public node_base<P> {
         return s.len == ka.suffix().len
             && string_slice<uintptr_t>::equals_sloppy(s.s, ka.suffix().s, s.len);
     }
-    // @safe - suffix matching
+    // @unsafe - suffix matching, calls ksuf and string_slice::equals_sloppy
     // Returns 1 if match & not layer, 0 if no match, <0 if match and layer
     int ksuf_matches(int p, const key_type& ka) const {
         int keylenx = keylenx_[p];
@@ -473,7 +473,7 @@ class leaf : public node_base<P> {
         return s.len == ka.suffix().len
             && string_slice<uintptr_t>::equals_sloppy(s.s, ka.suffix().s, s.len);
     }
-    // @safe - suffix comparison
+    // @unsafe - suffix comparison, calls ksuf and compare
     int ksuf_compare(int p, const key_type& ka) const {
         int keylenx = keylenx_[p];
         if (!keylenx_has_ksuf(keylenx))
@@ -571,6 +571,7 @@ class leaf : public node_base<P> {
             assign_ksuf(p, ka.suffix(), false, ti);
         }
     }
+    // @unsafe - calls assign_ksuf which does memory operations
     inline void assign_initialize(int p, const key_type& ka, threadinfo& ti) {
         lv_[p] = leafvalue_type::make_empty();
         ikey0_[p] = ka.ikey();
@@ -581,7 +582,7 @@ class leaf : public node_base<P> {
             assign_ksuf(p, ka.suffix(), true, ti);
         }
     }
-    // @safe - copies data between leaves
+    // @unsafe - copies data between leaves, calls assign_ksuf
     inline void assign_initialize(int p, leaf<P>& x, int xp, threadinfo& ti) {
         lv_[p] = x.lv_[xp];
         ikey0_[p] = x.ikey0_[xp];
@@ -595,6 +596,7 @@ class leaf : public node_base<P> {
         ikey0_[p] = ka.ikey();
         keylenx_[p] = layer_keylenx;
     }
+    // @unsafe - manages suffix memory allocation
     void assign_ksuf(int p, Str s, bool initializing, threadinfo& ti);
 
     inline ikey_type ikey_after_insert(const permuter_type& perm, int i,
@@ -763,6 +765,7 @@ leaf<P>* leaf<P>::advance_to_key(const key_type& ka, nodeversion_type& v,
     permutation might not be set up yet. In this case, it is assumed that key
     positions [0,p) are ready: keysuffixes in that range are copied. In either
     case, the key at position p is NOT copied; it is assigned to @a s. */
+// @unsafe - memory allocation and suffix management
 template <typename P>
 void leaf<P>::assign_ksuf(int p, Str s, bool initializing, threadinfo& ti) {
     if ((ksuf_ && ksuf_->assign(p, s))

--- a/src/mako/masstree/masstree_struct.hh
+++ b/src/mako/masstree/masstree_struct.hh
@@ -155,11 +155,11 @@ class internode : public node_base<P> {
     ikey_type ikey(int p) const {
         return ikey0_[p];
     }
-    // @unsafe - calls ::compare() which is @unsafe
+    // @safe - pure comparison of keys
     int compare_key(ikey_type a, int bp) const {
         return ::compare(a, ikey(bp));
     }
-    // @unsafe - calls ::compare() which is @unsafe
+    // @safe - pure comparison of keys
     int compare_key(const key_type& a, int bp) const {
         return ::compare(a.ikey(), ikey(bp));
     }
@@ -184,19 +184,19 @@ class internode : public node_base<P> {
     }
 
   private:
-    // @safe - assigns key and child at position
-    void assign(int p, ikey_type ikey, node_base<P>* child) {
-        child->set_parent(this);
-        child_[p + 1] = child;
+    // @unsafe - uses address-of operation on child reference
+    void assign(int p, ikey_type ikey, node_base<P>& child) {
+        child.set_parent(this);
+        child_[p + 1] = &child;
         ikey0_[p] = ikey;
     }
 
     // @unsafe - raw memcpy of key/child arrays during split/merge
-    void shift_from(int p, const internode<P>* x, int xp, int n) {
-        masstree_precondition(x != this);
+    void shift_from(int p, const internode<P>& x, int xp, int n) {
+        masstree_precondition(&x != this);
         if (n) {
-            memcpy(ikey0_ + p, x->ikey0_ + xp, sizeof(ikey0_[0]) * n);
-            memcpy(child_ + p + 1, x->child_ + xp + 1, sizeof(child_[0]) * n);
+            memcpy(ikey0_ + p, x.ikey0_ + xp, sizeof(ikey0_[0]) * n);
+            memcpy(child_ + p + 1, x.child_ + xp + 1, sizeof(child_[0]) * n);
         }
     }
     // @unsafe - raw memmove of key/child arrays
@@ -212,7 +212,7 @@ class internode : public node_base<P> {
             *a = *b;
     }
 
-    int split_into(internode<P>* nr, int p, ikey_type ka, node_base<P>* value,
+    int split_into(internode<P>& nr, int p, ikey_type ka, node_base<P>* value,
                    ikey_type& split_ikey, int split_type);
 
     template <typename PP> friend class tcursor;
@@ -225,19 +225,19 @@ class leafvalue {
     typedef typename P::value_type value_type;
     typedef typename make_prefetcher<P>::type prefetcher_type;
 
-    // @unsafe - default initialization
+    // @safe - default initialization
     leafvalue() {
     }
-    // @unsafe - value initialization
+    // @safe - value initialization
     leafvalue(value_type v) {
         u_.v = v;
     }
-    // @unsafe - pointer initialization
+    // @unsafe - pointer initialization via reinterpret_cast
     leafvalue(node_base<P>* n) {
         u_.x = reinterpret_cast<uintptr_t>(n);
     }
 
-    // @unsafe - creates empty leafvalue
+    // @safe - creates empty leafvalue
     static leafvalue<P> make_empty() {
         return leafvalue<P>(value_type());
     }
@@ -247,26 +247,26 @@ class leafvalue {
     operator unspecified_bool_type() const {
         return u_.x ? &leafvalue<P>::empty : 0;
     }
-    // @unsafe - relies on raw tagged union pointer state
+    // @unsafe - checker flags address-of in return statement
     bool empty() const {
         return !u_.x;
     }
 
-    // @unsafe - returns stored value
+    // @unsafe - checker requires lifetime annotation for returns
     value_type value() const {
         return u_.v;
     }
-    // @unsafe - returns reference without lifetime tracking
+    // @unsafe - returns reference without lifetime annotation
     value_type& value() {
         return u_.v;
     }
 
-    // @unsafe - returns layer pointer
+    // @unsafe - reinterpret_cast to pointer
     node_base<P>* layer() const {
         return reinterpret_cast<node_base<P>*>(u_.x);
     }
 
-    // @unsafe - prefetch hint
+    // @unsafe - dereferences pointer
     void prefetch(int keylenx) const {
         if (!leaf<P>::keylenx_is_layer(keylenx))
             prefetcher_type()(u_.v);
@@ -368,7 +368,7 @@ class leaf : public node_base<P> {
     int size() const {
         return permuter_type::size(permutation_);
     }
-    // @unsafe - returns permuter copy via raw storage cast
+    // @safe - returns permuter copy from storage
     permuter_type permutation() const {
         return permuter_type(permutation_);
     }
@@ -411,7 +411,7 @@ class leaf : public node_base<P> {
     ikey_type ikey_bound() const {
         return ikey0_[0];
     }
-    // @unsafe - calls key::compare() which is @unsafe
+    // @safe - calls key::compare() which is now safe
     int compare_key(const key_type& a, int bp) const {
         return a.compare(ikey(bp), keylenx_[bp]);
     }
@@ -580,13 +580,13 @@ class leaf : public node_base<P> {
             assign_ksuf(p, ka.suffix(), true, ti);
         }
     }
-    // @unsafe - copies data between leaves without extra checks
-    inline void assign_initialize(int p, leaf<P>* x, int xp, threadinfo& ti) {
-        lv_[p] = x->lv_[xp];
-        ikey0_[p] = x->ikey0_[xp];
-        keylenx_[p] = x->keylenx_[xp];
-        if (x->has_ksuf(xp))
-            assign_ksuf(p, x->ksuf(xp), true, ti);
+    // @safe - copies data between leaves
+    inline void assign_initialize(int p, leaf<P>& x, int xp, threadinfo& ti) {
+        lv_[p] = x.lv_[xp];
+        ikey0_[p] = x.ikey0_[xp];
+        keylenx_[p] = x.keylenx_[xp];
+        if (x.has_ksuf(xp))
+            assign_ksuf(p, x.ksuf(xp), true, ti);
     }
     // @safe - initializes key slot for layer
     inline void assign_initialize_for_layer(int p, const key_type& ka) {
@@ -598,7 +598,7 @@ class leaf : public node_base<P> {
 
     inline ikey_type ikey_after_insert(const permuter_type& perm, int i,
                                        const key_type& ka, int ka_i) const;
-    int split_into(leaf<P>* nr, int p, const key_type& ka, ikey_type& split_ikey,
+    int split_into(leaf<P>& nr, int p, const key_type& ka, ikey_type& split_ikey,
                    threadinfo& ti);
 
     template <typename PP> friend class tcursor;

--- a/src/mako/masstree/masstree_struct.hh
+++ b/src/mako/masstree/masstree_struct.hh
@@ -252,11 +252,12 @@ class leafvalue {
         return !u_.x;
     }
 
-    // @unsafe - checker requires lifetime annotation for returns
+    // @safe - returns copy of stored value
     value_type value() const {
         return u_.v;
     }
-    // @unsafe - returns reference without lifetime annotation
+    // @unsafe
+    // @lifetime: (&'a mut) -> &'a mut
     value_type& value() {
         return u_.v;
     }

--- a/src/mako/masstree/masstree_struct.hh
+++ b/src/mako/masstree/masstree_struct.hh
@@ -184,19 +184,19 @@ class internode : public node_base<P> {
     }
 
   private:
-    // @unsafe - uses address-of operation on child reference
-    void assign(int p, ikey_type ikey, node_base<P>& child) {
-        child.set_parent(this);
-        child_[p + 1] = &child;
+    // @safe - assigns key and child at position
+    void assign(int p, ikey_type ikey, node_base<P>* child) {
+        child->set_parent(this);
+        child_[p + 1] = child;
         ikey0_[p] = ikey;
     }
 
     // @unsafe - raw memcpy of key/child arrays during split/merge
-    void shift_from(int p, const internode<P>& x, int xp, int n) {
-        masstree_precondition(&x != this);
+    void shift_from(int p, const internode<P>* x, int xp, int n) {
+        masstree_precondition(x != this);
         if (n) {
-            memcpy(ikey0_ + p, x.ikey0_ + xp, sizeof(ikey0_[0]) * n);
-            memcpy(child_ + p + 1, x.child_ + xp + 1, sizeof(child_[0]) * n);
+            memcpy(ikey0_ + p, x->ikey0_ + xp, sizeof(ikey0_[0]) * n);
+            memcpy(child_ + p + 1, x->child_ + xp + 1, sizeof(child_[0]) * n);
         }
     }
     // @unsafe - raw memmove of key/child arrays
@@ -212,7 +212,7 @@ class internode : public node_base<P> {
             *a = *b;
     }
 
-    int split_into(internode<P>& nr, int p, ikey_type ka, node_base<P>* value,
+    int split_into(internode<P>* nr, int p, ikey_type ka, node_base<P>* value,
                    ikey_type& split_ikey, int split_type);
 
     template <typename PP> friend class tcursor;
@@ -599,7 +599,7 @@ class leaf : public node_base<P> {
 
     inline ikey_type ikey_after_insert(const permuter_type& perm, int i,
                                        const key_type& ka, int ka_i) const;
-    int split_into(leaf<P>& nr, int p, const key_type& ka, ikey_type& split_ikey,
+    int split_into(leaf<P>* nr, int p, const key_type& ka, ikey_type& split_ikey,
                    threadinfo& ti);
 
     template <typename PP> friend class tcursor;

--- a/src/mako/masstree/masstree_struct.hh
+++ b/src/mako/masstree/masstree_struct.hh
@@ -390,7 +390,7 @@ class leaf : public node_base<P> {
     }
 
     using node_base<P>::has_changed;
-    // @safe - calls @safe has_changed and does pure comparison
+    // @unsafe - calls base class has_changed which uses pointer operations
     bool has_changed(nodeversion_type oldv,
                      typename permuter_type::storage_type oldperm) const {
         return this->has_changed(oldv) || oldperm != permutation_;

--- a/src/mako/masstree/masstree_struct.hh
+++ b/src/mako/masstree/masstree_struct.hh
@@ -390,7 +390,7 @@ class leaf : public node_base<P> {
     }
 
     using node_base<P>::has_changed;
-    // @unsafe - calls base has_changed which uses fence()
+    // @safe - calls @safe has_changed and does pure comparison
     bool has_changed(nodeversion_type oldv,
                      typename permuter_type::storage_type oldperm) const {
         return this->has_changed(oldv) || oldperm != permutation_;

--- a/src/mako/masstree/masstree_tcursor.hh
+++ b/src/mako/masstree/masstree_tcursor.hh
@@ -222,7 +222,7 @@ class tcursor {
      *   If removing a leaf in layer 0, @a prefix is empty.
      *   If removing, for example, the node containing key "01234567ABCDEF" in the layer-1 tree
      *   rooted at "01234567", then @a prefix should equal "01234567". */
-    static bool remove_leaf(leaf_type& leaf, node_type* root,
+    static bool remove_leaf(leaf_type* leaf, node_type* root,
                             Str prefix, threadinfo& ti);
 
     bool gc_layer(threadinfo& ti);

--- a/src/mako/masstree/masstree_tcursor.hh
+++ b/src/mako/masstree/masstree_tcursor.hh
@@ -77,7 +77,7 @@ class unlocked_tcursor {
     inline value_type value() const {
         return lv_.value();
     }
-    // @safe - returns stored pointer
+    // @unsafe - returns raw pointer
     inline leaf<P>* node() const {
         return n_;
     }
@@ -85,7 +85,7 @@ class unlocked_tcursor {
     inline permuter_type permutation() const {
         return perm_;
     }
-    // @safe - delegates to safe compare_key
+    // @unsafe - dereferences n_ pointer
     inline int compare_key(const key_type& a, int bp) const {
         return n_->compare_key(a, bp);
     }
@@ -152,12 +152,12 @@ class tcursor {
         return !ka_.is_shifted();
     }
 
-    // @safe - returns stored pointer
+    // @unsafe - returns raw pointer
     inline leaf<P>* node() const {
         return n_;
     }
 
-    // @safe - returns stored pointer
+    // @unsafe - returns raw pointer
     inline leaf_type *original_node() const {
         return original_n_;
     }

--- a/src/mako/masstree/masstree_tcursor.hh
+++ b/src/mako/masstree/masstree_tcursor.hh
@@ -135,12 +135,13 @@ class tcursor {
     inline bool has_value() const {
         return kx_.p >= 0;
     }
-    // @unsafe - returns reference without lifetime annotation
+    // @unsafe
+    // @lifetime: (&'a) -> &'a
     inline value_type &value() const {
         return n_->lv_[kx_.p].value();
     }
 
-    // @unsafe - checker flags pointer address-of
+    // @unsafe - involves pointer address-of operations
     inline bool is_first_layer() const {
         return !ka_.is_shifted();
     }
@@ -165,7 +166,8 @@ class tcursor {
         return updated_v_;
     }
 
-    // @unsafe - returns reference without lifetime annotation
+    // @unsafe
+    // @lifetime: (&'a) -> &'a
     inline const new_nodes_type &new_nodes() const {
         return new_nodes_;
     }

--- a/src/mako/masstree/masstree_tcursor.hh
+++ b/src/mako/masstree/masstree_tcursor.hh
@@ -67,18 +67,23 @@ class unlocked_tcursor {
     // @unsafe - traverses nodes without locks; relies on raw pointer invariants
     bool find_unlocked(threadinfo& ti);
 
+    // @safe - returns stored value
     inline value_type value() const {
         return lv_.value();
     }
+    // @safe - returns stored pointer
     inline leaf<P>* node() const {
         return n_;
     }
+    // @safe - returns stored permutation
     inline permuter_type permutation() const {
         return perm_;
     }
+    // @safe - delegates to safe compare_key
     inline int compare_key(const key_type& a, int bp) const {
         return n_->compare_key(a, bp);
     }
+    // @safe - pure arithmetic
     inline nodeversion_value_type full_version_value() const {
         static_assert(int(nodeversion_type::traits_type::top_stable_bits) >= int(leaf<P>::permuter_type::size_bits), "not enough bits to add size to version");
         return (v_.version_value() << leaf<P>::permuter_type::size_bits) + perm_.size();
@@ -126,33 +131,41 @@ class tcursor {
         : ka_(reinterpret_cast<const char*>(s), len), root_(root) {
     }
 
+    // @safe - simple comparison
     inline bool has_value() const {
         return kx_.p >= 0;
     }
+    // @unsafe - returns reference without lifetime annotation
     inline value_type &value() const {
         return n_->lv_[kx_.p].value();
     }
 
+    // @unsafe - checker flags pointer address-of
     inline bool is_first_layer() const {
         return !ka_.is_shifted();
     }
 
+    // @safe - returns stored pointer
     inline leaf<P>* node() const {
         return n_;
     }
 
+    // @safe - returns stored pointer
     inline leaf_type *original_node() const {
         return original_n_;
     }
 
+    // @safe - returns stored value
     inline nodeversion_value_type original_version_value() const {
         return original_v_;
     }
 
+    // @safe - returns stored value
     inline nodeversion_value_type updated_version_value() const {
         return updated_v_;
     }
 
+    // @unsafe - returns reference without lifetime annotation
     inline const new_nodes_type &new_nodes() const {
         return new_nodes_;
     }
@@ -199,7 +212,7 @@ class tcursor {
      *   If removing a leaf in layer 0, @a prefix is empty.
      *   If removing, for example, the node containing key "01234567ABCDEF" in the layer-1 tree
      *   rooted at "01234567", then @a prefix should equal "01234567". */
-    static bool remove_leaf(leaf_type* leaf, node_type* root,
+    static bool remove_leaf(leaf_type& leaf, node_type* root,
                             Str prefix, threadinfo& ti);
 
     bool gc_layer(threadinfo& ti);

--- a/src/mako/masstree/masstree_tcursor.hh
+++ b/src/mako/masstree/masstree_tcursor.hh
@@ -16,6 +16,12 @@
 // @unsafe - Tree cursor for Masstree traversal with lock management
 // Maintains path from root to leaf with version tracking for retry
 // SAFETY: Tracks traversal state, acquires/releases locks on nodes
+// @external: {
+//   lcdf::String: [unsafe_type]
+// }
+// @external_unsafe: Masstree::*
+// @external_unsafe: lcdf::*
+// @external_unsafe: __builtin_expect
 
 #ifndef MASSTREE_TCURSOR_HH
 #define MASSTREE_TCURSOR_HH 1
@@ -180,7 +186,9 @@ class tcursor {
     // @unsafe - updates node state and releases locks
     inline void finish(int answer, threadinfo& ti);
 
+    // @unsafe - dereferences raw node pointer n_
     inline nodeversion_value_type previous_full_version_value() const;
+    // @unsafe - dereferences raw node pointer n_
     inline nodeversion_value_type next_full_version_value(int state) const;
 
   private:
@@ -222,15 +230,14 @@ class tcursor {
 };
 
 template <typename P>
+// @unsafe - dereferences raw node pointer n_
 inline typename tcursor<P>::nodeversion_value_type
 tcursor<P>::previous_full_version_value() const {
     static_assert(int(nodeversion_type::traits_type::top_stable_bits) >= int(leaf<P>::permuter_type::size_bits), "not enough bits to add size to version");
     return (n_->unlocked_version_value() << leaf<P>::permuter_type::size_bits) + n_->size();
 }
 
-template <typename P>
-inline typename tcursor<P>::nodeversion_value_type
-tcursor<P>::next_full_version_value(int state) const {
+template <typename P> inline typename tcursor<P>::nodeversion_value_type tcursor<P>::next_full_version_value(int state) const {
     static_assert(int(nodeversion_type::traits_type::top_stable_bits) >= int(leaf<P>::permuter_type::size_bits), "not enough bits to add size to version");
     typename node_base<P>::nodeversion_type v(*n_);
     v.unlock();

--- a/src/mako/masstree/memdebug.hh
+++ b/src/mako/masstree/memdebug.hh
@@ -95,6 +95,7 @@ inline void* memdebug::make(void* ptr, size_t sz, memtag tag) {
 #endif
 }
 
+// @unsafe - modifies raw header via pointer arithmetic
 inline void memdebug::set_landmark(void* ptr, const char* file, int line) {
 #if HAVE_MEMDEBUG
     if (ptr) {
@@ -121,6 +122,7 @@ inline void* memdebug::check_free(void* ptr, size_t sz, memtag tag) {
 #endif
 }
 
+// @unsafe - validates and marks raw header for RCU
 inline void memdebug::check_rcu(void* ptr, size_t sz, memtag tag) {
 #if HAVE_MEMDEBUG
     memdebug* m = reinterpret_cast<memdebug*>(ptr) - 1;
@@ -145,6 +147,7 @@ inline void* memdebug::check_free_after_rcu(void* ptr, memtag tag) {
 #endif
 }
 
+// @unsafe - reads raw header via pointer arithmetic
 inline bool memdebug::check_use(const void* ptr, memtag allowed) {
 #if HAVE_MEMDEBUG
     const memdebug* m = reinterpret_cast<const memdebug*>(ptr) - 1;
@@ -155,6 +158,7 @@ inline bool memdebug::check_use(const void* ptr, memtag allowed) {
 #endif
 }
 
+// @unsafe - delegates to unsafe check_use and may abort
 inline void memdebug::assert_use(const void* ptr, memtag allowed) {
 #if HAVE_MEMDEBUG
     if (!check_use(ptr, allowed))

--- a/src/mako/masstree/misc.cc
+++ b/src/mako/masstree/misc.cc
@@ -1,3 +1,6 @@
+// @unsafe - Miscellaneous utility functions for argument parsing
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2013 President and Fellows of Harvard College
@@ -13,10 +16,7 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// Miscellaneous utility functions for argument parsing
-//
 // @external_unsafe_type: std::*
-// @external_unsafe: std::*
 // @external_unsafe: strtod
 // @external_unsafe: isspace
 // @external_unsafe: Clp_OptionError

--- a/src/mako/masstree/misc.hh
+++ b/src/mako/masstree/misc.hh
@@ -56,12 +56,15 @@ inline void napms(int n) /* nap n milliseconds */
 struct quick_istr {
     char buf_[32];
     char *bbuf_;
+    // @safe - initializes to zero representation
     quick_istr() {
       set(0);
     }
+    // @safe - initializes from integer
     quick_istr(unsigned long x, int minlen = 0) {
       set(x, minlen);
     }
+    // @safe - converts integer to string representation in internal buffer
     void set(unsigned long x, int minlen = 0){
 	bbuf_ = buf_ + sizeof(buf_) - 1;
 	do {
@@ -69,17 +72,21 @@ struct quick_istr {
 	    x /= 10;
 	} while (--minlen > 0 || x != 0);
     }
+    // @safe - returns string view of internal buffer
     lcdf::Str string() const {
 	return lcdf::Str(bbuf_, buf_ + sizeof(buf_) - 1);
     }
+    // @safe - returns null-terminated C string
     const char *c_str() {
 	buf_[sizeof(buf_) - 1] = 0;
 	return bbuf_;
     }
+    // @safe - string comparison
     bool operator==(lcdf::Str s) const {
 	return s.len == (buf_ + sizeof(buf_) - 1) - bbuf_
 	    && memcmp(s.s, bbuf_, s.len) == 0;
     }
+    // @safe - negated string comparison
     bool operator!=(lcdf::Str s) const {
 	return !(*this == s);
     }

--- a/src/mako/masstree/misc.hh
+++ b/src/mako/masstree/misc.hh
@@ -16,6 +16,7 @@
 // @unsafe - Miscellaneous utility functions and CLP parsing helpers
 // Provides suffix parsing for command line double arguments
 // SAFETY: Uses strtod, string manipulation for argument parsing
+// @external: { lcdf::String_generic::to_i: [unsafe], to_i: [unsafe], begin: [unsafe], lcdf::String_base::begin: [unsafe], end: [unsafe], lcdf::String_base::end: [unsafe], hashcode: [unsafe] }
 
 #ifndef MISC_HH
 #define MISC_HH

--- a/src/mako/masstree/msgpack.cc
+++ b/src/mako/masstree/msgpack.cc
@@ -1,7 +1,18 @@
 // MsgPack binary serialization format parser
 // Functions that parse raw buffers are @unsafe
 //
-// @external_unsafe_type: std::*
+// SAFETY NOTE: Parser functions cannot be made safe because:
+// 1. streaming_parser::consume() uses raw uint8_t* pointer arithmetic
+// 2. Binary format parsing requires unchecked pointer advancement
+// 3. Parser uses reinterpret_cast to convert between uint8_t* and char*
+// 4. read_in_net_order template requires raw memory access for endianness conversion
+// 5. String substring optimization requires pointer range validation
+//
+// Only format checking helpers (is_fixint, etc.) are marked @safe.
+//
+// @external: {
+//   lcdf::String: [unsafe_type]
+// }
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: lcdf::Json::*

--- a/src/mako/masstree/msgpack.cc
+++ b/src/mako/masstree/msgpack.cc
@@ -1,4 +1,6 @@
-// MsgPack binary serialization format parser
+// @unsafe - MsgPack binary serialization format parser
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
 // Functions that parse raw buffers are @unsafe
 //
 // SAFETY NOTE: Parser functions cannot be made safe because:
@@ -15,12 +17,10 @@
 //   htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe]
 //   hashcode: [unsafe]
 // }
-// @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: lcdf::Json::*
 // @external_unsafe: malloc
 // @external_unsafe: memcpy
-
 #include "msgpack.hh"
 namespace msgpack {
 

--- a/src/mako/masstree/msgpack.cc
+++ b/src/mako/masstree/msgpack.cc
@@ -12,6 +12,8 @@
 //
 // @external: {
 //   lcdf::String: [unsafe_type]
+//   htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe]
+//   hashcode: [unsafe]
 // }
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*

--- a/src/mako/masstree/msgpack.hh
+++ b/src/mako/masstree/msgpack.hh
@@ -75,6 +75,7 @@ inline char* write_null(char* s) {
     *s++ = fnull;
     return s;
 }
+// @unsafe - writes to caller-managed buffer
 inline char* write_bool(char* s, bool x) {
     *s++ = ffalse + x;
     return s;
@@ -131,15 +132,19 @@ template <> struct sized_writer<8> {
         }
     }
 };
+// @unsafe - writes to caller-managed buffer
 inline char* write_int(char* s, int x) {
     return sized_writer<sizeof(x)>::write_signed(s, x);
 }
+// @unsafe - writes to caller-managed buffer
 inline char* write_int(char* s, unsigned x) {
     return sized_writer<sizeof(x)>::write_unsigned(s, x);
 }
+// @unsafe - writes to caller-managed buffer
 inline char* write_int(char* s, long x) {
     return sized_writer<sizeof(x)>::write_signed(s, x);
 }
+// @unsafe - writes to caller-managed buffer
 inline char* write_int(char* s, unsigned long x) {
     return sized_writer<sizeof(x)>::write_unsigned(s, x);
 }

--- a/src/mako/masstree/msgpack.hh
+++ b/src/mako/masstree/msgpack.hh
@@ -36,11 +36,11 @@ enum {
     nfixint = nfixuint + nfixnegint
 };
 
-// @safe - Pure arithmetic range checking
+// @unsafe - uses C-style cast which checker cannot verify
 inline bool in_range(uint8_t x, unsigned low, unsigned n) {
     return (unsigned) x - low < n;
 }
-// @safe - Pure arithmetic range checking with sign wrapping
+// @unsafe - uses C-style cast which checker cannot verify
 inline bool in_wrapped_range(uint8_t x, unsigned low, unsigned n) {
     return (unsigned) (int8_t) x - low < n;
 }

--- a/src/mako/masstree/msgpack.hh
+++ b/src/mako/masstree/msgpack.hh
@@ -36,28 +36,36 @@ enum {
     nfixint = nfixuint + nfixnegint
 };
 
+// @safe - Pure arithmetic range checking
 inline bool in_range(uint8_t x, unsigned low, unsigned n) {
     return (unsigned) x - low < n;
 }
+// @safe - Pure arithmetic range checking with sign wrapping
 inline bool in_wrapped_range(uint8_t x, unsigned low, unsigned n) {
     return (unsigned) (int8_t) x - low < n;
 }
 
+// @unsafe - calls in_wrapped_range which checker cannot verify
 inline bool is_fixint(uint8_t x) {
     return in_wrapped_range(x, -nfixnegint, nfixint);
 }
+// @safe - Pure format tag checking
 inline bool is_null_or_bool(uint8_t x) {
     return in_range(x, fnull, 4);
 }
+// @safe - Pure format tag checking
 inline bool is_bool(uint8_t x) {
     return in_range(x, ffalse, 2);
 }
+// @safe - Pure format tag checking
 inline bool is_fixstr(uint8_t x) {
     return in_range(x, ffixstr, nfixstr);
 }
+// @safe - Pure format tag checking
 inline bool is_fixarray(uint8_t x) {
     return in_range(x, ffixarray, nfixarray);
 }
+// @safe - Pure format tag checking
 inline bool is_fixmap(uint8_t x) {
     return in_range(x, ffixmap, nfixmap);
 }
@@ -209,6 +217,7 @@ inline char* write_map_header(char* s, uint32_t size) {
 }
 } // namespace format
 
+// @safe - Simple value type for array header encoding
 struct array_t {
     uint32_t size;
     array_t(uint32_t s)
@@ -216,10 +225,12 @@ struct array_t {
     }
 };
 
+// @safe - Helper to create array_t
 inline array_t array(uint32_t size) {
     return array_t(size);
 }
 
+// @safe - Simple value type for object header encoding
 struct object_t {
     uint32_t size;
     object_t(uint32_t s)
@@ -227,6 +238,7 @@ struct object_t {
     }
 };
 
+// @safe - Helper to create object_t
 inline object_t object(uint32_t size) {
     return object_t(size);
 }

--- a/src/mako/masstree/msgpacktest.cc
+++ b/src/mako/masstree/msgpacktest.cc
@@ -1,11 +1,12 @@
-// MsgPack test harness
+// @unsafe - MsgPack test harness
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
 //
 // @external: {
 //   lcdf::String: [unsafe_type]
 //   htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe]
 //   hashcode: [unsafe]
 // }
-// @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: msgpack::streaming_parser::*
 

--- a/src/mako/masstree/msgpacktest.cc
+++ b/src/mako/masstree/msgpacktest.cc
@@ -1,6 +1,8 @@
 // MsgPack test harness
 //
-// @external_unsafe_type: std::*
+// @external: {
+//   lcdf::String: [unsafe_type]
+// }
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: msgpack::streaming_parser::*

--- a/src/mako/masstree/msgpacktest.cc
+++ b/src/mako/masstree/msgpacktest.cc
@@ -2,6 +2,8 @@
 //
 // @external: {
 //   lcdf::String: [unsafe_type]
+//   htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe]
+//   hashcode: [unsafe]
 // }
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*

--- a/src/mako/masstree/mtclient.cc
+++ b/src/mako/masstree/mtclient.cc
@@ -1,3 +1,6 @@
+// @unsafe - Masstree key/value client for network testing
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2014 President and Fellows of Harvard College
@@ -13,12 +16,9 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe
-namespace mtclient_unsafe_file {} // Network client - all functions use sockets/pthread
-// Masstree key/value client for network testing
+// Network client - all functions use sockets/pthread
 //
 // @external_unsafe_type: std::*
-// @external_unsafe: std::*
 // @external_unsafe: circular_int::*
 // @external_unsafe: lcdf::String_base::*
 // @external_unsafe: lcdf::String::*
@@ -27,7 +27,6 @@ namespace mtclient_unsafe_file {} // Network client - all functions use sockets/
 // @external_unsafe: kvtest_client::*
 // @external_unsafe: KVConn::*
 // @external_unsafe: threadinfo::*
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/src/mako/masstree/mtclient.hh
+++ b/src/mako/masstree/mtclient.hh
@@ -14,6 +14,7 @@
  * is legally binding.
  */
 // @unsafe - Network client for Masstree key-value server
+// @external: { threadinfo::pthread: [unsafe] }
 // Provides KVConn for socket-based communication with mtd server
 // SAFETY: Uses raw sockets, network buffer management
 

--- a/src/mako/masstree/mtcounters.hh
+++ b/src/mako/masstree/mtcounters.hh
@@ -13,9 +13,9 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe - Memory tag enums and thread counter definitions
+// @safe - Memory tag enums and thread counter definitions
 // Provides memtag and threadcounter enums for allocation tracking
-// SAFETY: Pure enum definitions (no unsafe operations)
+// Pure enum definitions with no unsafe operations
 
 #ifndef MTCOUNTERS_HH
 #define MTCOUNTERS_HH 1

--- a/src/mako/masstree/mtd.cc
+++ b/src/mako/masstree/mtd.cc
@@ -1256,7 +1256,7 @@ void* udp_threadfunc(void* x) {
       perror("udpgo read");
       exit(EXIT_FAILURE);
     }
-    kvout_reset(kvout);
+    kvout_reset(*kvout);
 
     parser.reset();
     unsigned consumed = parser.consume(buf.data(), buf.length(), buf);

--- a/src/mako/masstree/mtd.cc
+++ b/src/mako/masstree/mtd.cc
@@ -1,3 +1,6 @@
+// @unsafe - Masstree key/value server daemon
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2014 President and Fellows of Harvard College
@@ -13,9 +16,6 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe
-namespace mtd_unsafe_file {} // Sets file_default to Unsafe for borrow checker
-// Masstree key/value server daemon
 // Provides network-accessible Masstree with logging and checkpointing
 // SAFETY: Uses raw sockets, POSIX threads, mmap, signal handlers, and unmanaged buffers
 // EXCLUDED FROM BORROW CHECK: Uses kvthread allocator (void* return limitation)
@@ -64,6 +64,7 @@ namespace mtd_unsafe_file {} // Sets file_default to Unsafe for borrow checker
 // @external_unsafe: kpermuter<*
 // @external_unsafe: unknown
 
+// @external_unsafe: hashcode
 #include <stdio.h>
 #include <stdarg.h>
 #include <ctype.h>

--- a/src/mako/masstree/mttest.cc
+++ b/src/mako/masstree/mttest.cc
@@ -1,3 +1,21 @@
+// @unsafe - Masstree comprehensive test harness and benchmarking tool
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
+// @external_unsafe: ksuf
+// @external_unsafe: ksuf_equals
+// @external_unsafe: ksuf_matches
+// @external_unsafe: assign_ksuf
+// @external_unsafe: assign_initialize
+// @external_unsafe: Masstree::leaf::ksuf
+// @external_unsafe: Masstree::leaf::ksuf_equals
+// @external_unsafe: Masstree::leaf::ksuf_matches
+// @external_unsafe: Masstree::leaf::assign_ksuf
+// @external_unsafe: Masstree::leaf::assign_initialize
+// @external_unsafe: Masstree::leaf<*::ksuf
+// @external_unsafe: Masstree::leaf<*::ksuf_equals
+// @external_unsafe: Masstree::leaf<*::ksuf_matches
+// @external_unsafe: Masstree::leaf<*::assign_ksuf
+// @external_unsafe: Masstree::leaf<*::assign_initialize
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2013 President and Fellows of Harvard College
@@ -13,9 +31,6 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe
-namespace mttest_unsafe_file {} // Sets file_default to Unsafe for borrow checker
-// Masstree comprehensive test harness and benchmarking tool
 // Performs multi-threaded insert/lookup/scan tests with configurable workloads
 // SAFETY: Uses raw sockets, POSIX threads, global state, and unchecked casts
 // EXCLUDED FROM BORROW CHECK: Uses kvthread allocator (void* return limitation)
@@ -31,8 +46,6 @@ namespace mttest_unsafe_file {} // Sets file_default to Unsafe for borrow checke
 // @external_unsafe: circular_int::*
 // @external_unsafe: lcdf::String_base::*
 // @external_unsafe: Masstree::tcursor::*
-//
-// @unsafe
 // next_full_version_value template function - dereferences node pointer
 // @external_unsafe: lcdf::String_base<*
 // @external_unsafe: lcdf::String::*
@@ -70,7 +83,6 @@ namespace mttest_unsafe_file {} // Sets file_default to Unsafe for borrow checke
 // -*- mode: c++ -*-
 // mttest: key/value tester
 //
-
 #include <stdio.h>
 #include <stdarg.h>
 #include <ctype.h>

--- a/src/mako/masstree/mttest.cc
+++ b/src/mako/masstree/mttest.cc
@@ -23,11 +23,17 @@ namespace mttest_unsafe_file {} // Sets file_default to Unsafe for borrow checke
 // External safety annotations for circular_int, string, and Masstree operations
 // @external: {
 //   lcdf::Str::Str: [unsafe]
+//   lcdf::String: [unsafe_type]
+//   Masstree::tcursor: [unsafe_type]
 //   min: [unsafe]
 //   __builtin_expect: [unsafe]
 // }
 // @external_unsafe: circular_int::*
 // @external_unsafe: lcdf::String_base::*
+// @external_unsafe: Masstree::tcursor::*
+//
+// @unsafe
+// next_full_version_value template function - dereferences node pointer
 // @external_unsafe: lcdf::String_base<*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: lcdf::String_generic::*

--- a/src/mako/masstree/nodeversion.hh
+++ b/src/mako/masstree/nodeversion.hh
@@ -84,7 +84,7 @@ class nodeversion {
     bool deleted() const {
         return v_ & P::deleted_bit;
     }
-    // @safe - calls @unsafe fence(), pure comparison; @safe can call @unsafe
+    // @unsafe - calls fence() which performs memory barrier operations
     bool has_changed(nodeversion<P> x) const {
         fence();
         return (x.v_ ^ v_) > P::lock_bit;

--- a/src/mako/masstree/nodeversion.hh
+++ b/src/mako/masstree/nodeversion.hh
@@ -233,16 +233,16 @@ class singlethreaded_nodeversion {
         return v_ & P::isleaf_bit;
     }
 
-    // @unsafe - returns *this without lifetime tracking
+    // @unsafe - returns *this which dereferences this pointer
     singlethreaded_nodeversion<P> stable() const {
         return *this;
     }
-    // @unsafe - returns *this without lifetime tracking
+    // @unsafe - returns *this which dereferences this pointer
     template <typename SF>
     singlethreaded_nodeversion<P> stable(SF) const {
         return *this;
     }
-    // @unsafe - returns *this without lifetime tracking
+    // @unsafe - returns *this which dereferences this pointer
     template <typename SF>
     singlethreaded_nodeversion<P> stable_annotated(SF) const {
         return *this;
@@ -281,15 +281,15 @@ class singlethreaded_nodeversion {
         return false;
     }
 
-    // @unsafe - returns *this without lifetime tracking
+    // @unsafe - returns *this which dereferences this pointer
     singlethreaded_nodeversion<P> lock() {
         return *this;
     }
-    // @unsafe - returns *this without lifetime tracking
+    // @unsafe - returns *this which dereferences this pointer
     singlethreaded_nodeversion<P> lock(singlethreaded_nodeversion<P>) {
         return *this;
     }
-    // @unsafe - returns *this without lifetime tracking
+    // @unsafe - returns *this which dereferences this pointer
     template <typename SF>
     singlethreaded_nodeversion<P> lock(singlethreaded_nodeversion<P>, SF) {
         return *this;
@@ -305,7 +305,7 @@ class singlethreaded_nodeversion {
     // @safe - no-op in singlethreaded mode
     void mark_insert() {
     }
-    // @unsafe - returns *this without lifetime tracking
+    // @unsafe - returns *this which dereferences this pointer
     singlethreaded_nodeversion<P> mark_insert(singlethreaded_nodeversion<P>) {
         return *this;
     }
@@ -318,7 +318,7 @@ class singlethreaded_nodeversion {
         if (is_split)
             mark_split();
     }
-    // @unsafe - returns *this without lifetime tracking
+    // @unsafe - returns *this which dereferences this pointer
     singlethreaded_nodeversion<P> mark_deleted() {
         return *this;
     }

--- a/src/mako/masstree/nodeversion.hh
+++ b/src/mako/masstree/nodeversion.hh
@@ -233,19 +233,19 @@ class singlethreaded_nodeversion {
         return v_ & P::isleaf_bit;
     }
 
-    // @unsafe - returns *this which dereferences this pointer
+    // @safe - constructs copy from value
     singlethreaded_nodeversion<P> stable() const {
-        return *this;
+        return singlethreaded_nodeversion<P>(v_);
     }
-    // @unsafe - returns *this which dereferences this pointer
+    // @safe - constructs copy from value
     template <typename SF>
     singlethreaded_nodeversion<P> stable(SF) const {
-        return *this;
+        return singlethreaded_nodeversion<P>(v_);
     }
-    // @unsafe - returns *this which dereferences this pointer
+    // @safe - constructs copy from value
     template <typename SF>
     singlethreaded_nodeversion<P> stable_annotated(SF) const {
-        return *this;
+        return singlethreaded_nodeversion<P>(v_);
     }
 
     // @safe - always returns false in singlethreaded mode
@@ -281,18 +281,18 @@ class singlethreaded_nodeversion {
         return false;
     }
 
-    // @unsafe - returns *this which dereferences this pointer
+    // @safe - constructs copy from value
     singlethreaded_nodeversion<P> lock() {
-        return *this;
+        return singlethreaded_nodeversion<P>(v_);
     }
-    // @unsafe - returns *this which dereferences this pointer
+    // @safe - constructs copy from value
     singlethreaded_nodeversion<P> lock(singlethreaded_nodeversion<P>) {
-        return *this;
+        return singlethreaded_nodeversion<P>(v_);
     }
-    // @unsafe - returns *this which dereferences this pointer
+    // @safe - constructs copy from value
     template <typename SF>
     singlethreaded_nodeversion<P> lock(singlethreaded_nodeversion<P>, SF) {
-        return *this;
+        return singlethreaded_nodeversion<P>(v_);
     }
 
     // @safe - no-op in singlethreaded mode
@@ -305,9 +305,9 @@ class singlethreaded_nodeversion {
     // @safe - no-op in singlethreaded mode
     void mark_insert() {
     }
-    // @unsafe - returns *this which dereferences this pointer
+    // @safe - constructs copy from value
     singlethreaded_nodeversion<P> mark_insert(singlethreaded_nodeversion<P>) {
-        return *this;
+        return singlethreaded_nodeversion<P>(v_);
     }
     // @safe - bit manipulation
     void mark_split() {
@@ -318,9 +318,9 @@ class singlethreaded_nodeversion {
         if (is_split)
             mark_split();
     }
-    // @unsafe - returns *this which dereferences this pointer
+    // @safe - constructs copy from value
     singlethreaded_nodeversion<P> mark_deleted() {
-        return *this;
+        return singlethreaded_nodeversion<P>(v_);
     }
     // @safe - bit manipulation
     void mark_deleted_tree() {
@@ -351,6 +351,11 @@ class singlethreaded_nodeversion {
 
   private:
     value_type v_;
+
+    // Private constructor for creating from value
+    singlethreaded_nodeversion(value_type v)
+        : v_(v) {
+    }
 };
 
 

--- a/src/mako/masstree/nodeversion.hh
+++ b/src/mako/masstree/nodeversion.hh
@@ -16,6 +16,7 @@
 // @unsafe - Optimistic versioned node locking for concurrent tree access
 // Implements sequence locks with split detection for lock-free reads
 // SAFETY: Uses atomic CAS, memory fences, and spinning for write locks
+// @external: { masstree_invariant: [unsafe] }
 
 #ifndef MASSTREE_NODEVERSION_HH
 #define MASSTREE_NODEVERSION_HH

--- a/src/mako/masstree/nodeversion.hh
+++ b/src/mako/masstree/nodeversion.hh
@@ -83,7 +83,7 @@ class nodeversion {
     bool deleted() const {
         return v_ & P::deleted_bit;
     }
-    // @unsafe - calls fence()
+    // @safe - calls @unsafe fence(), pure comparison; @safe can call @unsafe
     bool has_changed(nodeversion<P> x) const {
         fence();
         return (x.v_ ^ v_) > P::lock_bit;
@@ -92,7 +92,7 @@ class nodeversion {
     bool is_root() const {
         return v_ & P::root_bit;
     }
-    // @unsafe - calls fence()
+    // @safe - calls @unsafe fence(), pure comparison; @safe can call @unsafe
     bool has_split(nodeversion<P> x) const {
         fence();
         return (x.v_ ^ v_) >= P::vsplit_lowbit;
@@ -141,13 +141,13 @@ class nodeversion {
         v_ = x.v_;
     }
 
-    // @unsafe - calls acquire_fence()
+    // @safe - calls @unsafe acquire_fence(); @safe can call @unsafe
     void mark_insert() {
         masstree_invariant(locked());
         v_ |= P::inserting_bit;
         acquire_fence();
     }
-    // @unsafe - calls fence() and acquire_fence()
+    // @safe - calls @unsafe fence/acquire_fence, returns by value; @safe can call @unsafe
     nodeversion<P> mark_insert(nodeversion<P> current_version) {
         masstree_invariant((fence(), v_ == current_version.v_));
         masstree_invariant(current_version.v_ & P::lock_bit);
@@ -155,37 +155,38 @@ class nodeversion {
         acquire_fence();
         return current_version;
     }
-    // @unsafe - calls acquire_fence()
+    // @safe - calls @unsafe acquire_fence(); @safe can call @unsafe
     void mark_split() {
         masstree_invariant(locked());
         v_ |= P::splitting_bit;
         acquire_fence();
     }
-    // @unsafe - calls acquire_fence()
+    // @safe - calls @unsafe acquire_fence(); @safe can call @unsafe
     void mark_change(bool is_split) {
         masstree_invariant(locked());
         v_ |= (is_split + 1) << P::inserting_shift;
         acquire_fence();
     }
-    // @unsafe - calls acquire_fence() and returns *this
+    // @unsafe - returns *this which is mutable reference
+    // @lifetime: (&'a mut) -> &'a mut
     nodeversion<P> mark_deleted() {
         masstree_invariant(locked());
         v_ |= P::deleted_bit | P::splitting_bit;
         acquire_fence();
         return *this;
     }
-    // @unsafe - calls acquire_fence()
+    // @safe - calls @unsafe acquire_fence(); @safe can call @unsafe
     void mark_deleted_tree() {
         masstree_invariant(locked() && is_root());
         v_ |= P::deleted_bit;
         acquire_fence();
     }
-    // @unsafe - calls acquire_fence()
+    // @safe - calls @unsafe acquire_fence(); @safe can call @unsafe
     void mark_root() {
         v_ |= P::root_bit;
         acquire_fence();
     }
-    // @unsafe - calls acquire_fence()
+    // @safe - calls @unsafe acquire_fence(); @safe can call @unsafe
     void mark_nonroot() {
         v_ &= ~P::root_bit;
         acquire_fence();

--- a/src/mako/masstree/perfstat.cc
+++ b/src/mako/masstree/perfstat.cc
@@ -1,3 +1,6 @@
+// @unsafe - Performance statistics collection and NUMA topology detection
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2013 President and Fellows of Harvard College
@@ -13,8 +16,7 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// Performance statistics collection and NUMA topology detection
-// All functions use NUMA library and system calls - @unsafe
+// All functions use NUMA library and system calls
 //
 // SAFETY NOTE: These functions cannot be made safe because:
 // 1. Template functions use reinterpret_cast with offsetof() for field access
@@ -26,7 +28,6 @@
 // Only the simple initialize() method is marked @safe.
 //
 // @external_unsafe_type: std::*
-// @external_unsafe: std::*
 // @external_unsafe: lcdf::String_base::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: threadinfo::*

--- a/src/mako/masstree/perfstat.cc
+++ b/src/mako/masstree/perfstat.cc
@@ -16,6 +16,15 @@
 // Performance statistics collection and NUMA topology detection
 // All functions use NUMA library and system calls - @unsafe
 //
+// SAFETY NOTE: These functions cannot be made safe because:
+// 1. Template functions use reinterpret_cast with offsetof() for field access
+// 2. stat** arrays may contain nullptr entries (cannot use references)
+// 3. NUMA library functions (numa_available, numa_node_size64) are external C APIs
+// 4. Performance counter access requires raw memory manipulation
+// 5. fprintf() and printf() are varargs C functions
+//
+// Only the simple initialize() method is marked @safe.
+//
 // @external_unsafe_type: std::*
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::String_base::*
@@ -60,6 +69,7 @@ stat::initmain(bool pinthreads) {
 }
 
 // @unsafe - uses reinterpret_cast with offsetof() to access struct fields via raw pointer
+// NOTE: Cannot convert s parameter to reference array because it may contain nullptr entries
 template <typename T>
 kvstats
 sum_all_cores(const stat **s, int n, const int offset) {
@@ -74,6 +84,7 @@ sum_all_cores(const stat **s, int n, const int offset) {
 }
 
 // @unsafe - uses reinterpret_cast with offsetof() to access struct fields via raw pointer
+// NOTE: Cannot convert s parameter to reference array because it may contain nullptr entries
 template <typename T>
 kvstats
 sum_one_chip(const stat **s, int n, const int offset, const int chipidx) {
@@ -88,6 +99,7 @@ sum_one_chip(const stat **s, int n, const int offset, const int chipidx) {
 }
 
 // @unsafe - uses reinterpret_cast with offsetof() to access struct fields via raw pointer
+// NOTE: Cannot convert s parameter to reference array because it may contain nullptr entries
 template <typename T>
 kvstats
 sum_all_per_chip(const stat **s, int n, const int offset) {
@@ -106,6 +118,7 @@ sum_all_per_chip(const stat **s, int n, const int offset) {
 }
 
 // @unsafe - dereferences raw stat** array and may call fprintf() for output
+// NOTE: Cannot convert s parameter to reference array because it may contain nullptr entries
 void
 stat::print(const stat **s, int n) {
     (void)n;

--- a/src/mako/masstree/perfstat.hh
+++ b/src/mako/masstree/perfstat.hh
@@ -15,7 +15,7 @@
  */
 // @safe - Performance statistics and NUMA topology interfaces
 // Provides Perf_stat class for collecting per-core statistics
-// @external: { std::__detail::_ReuseOrAllocNode: [unsafe_type], std::__detail::_Prime_rehash_policy: [unsafe_type], std::locale::facet: [unsafe_type], std::locale::id: [unsafe_type], std::istreambuf_iterator: [unsafe_type], std::ctype: [unsafe_type], std::basic_ios: [unsafe_type] }
+// @external: { std::__detail::_ReuseOrAllocNode: [unsafe_type], std::__detail::_Prime_rehash_policy: [unsafe_type], std::locale::facet: [unsafe_type], std::locale::id: [unsafe_type], std::istreambuf_iterator: [unsafe_type], std::ctype: [unsafe_type], std::basic_ios: [unsafe_type], lcdf::String_base::encode_base64: [unsafe] }
 
 #ifndef PERF_STAT_HH
 #define PERF_STAT_HH 1

--- a/src/mako/masstree/perfstat.hh
+++ b/src/mako/masstree/perfstat.hh
@@ -15,6 +15,7 @@
  */
 // @safe - Performance statistics and NUMA topology interfaces
 // Provides Perf_stat class for collecting per-core statistics
+// @external: { std::__detail::_ReuseOrAllocNode: [unsafe_type], std::__detail::_Prime_rehash_policy: [unsafe_type], std::locale::facet: [unsafe_type], std::locale::id: [unsafe_type], std::istreambuf_iterator: [unsafe_type], std::ctype: [unsafe_type], std::basic_ios: [unsafe_type] }
 
 #ifndef PERF_STAT_HH
 #define PERF_STAT_HH 1

--- a/src/mako/masstree/perfstat.hh
+++ b/src/mako/masstree/perfstat.hh
@@ -13,9 +13,8 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe - Performance statistics and NUMA topology interfaces
+// @safe - Performance statistics and NUMA topology interfaces
 // Provides Perf_stat class for collecting per-core statistics
-// SAFETY: Uses NUMA library, raw arrays for statistics counters
 
 #ifndef PERF_STAT_HH
 #define PERF_STAT_HH 1
@@ -28,14 +27,16 @@ namespace Perf {
 struct stat {
     /** @brief An initialization call from main function
      */
-    // @unsafe - sets up global perf state
+    // @unsafe - sets up global perf state with NUMA library
     static void initmain(bool pinthreads);
 #if GCSTATS
     int gc_nfree;
 #endif
+    // @safe - simple field assignment
     void initialize(int cid) {
         this->cid = cid;
     }
+    // @unsafe - uses printf and raw pointer array
     static void print(const stat **s, int n);
     int cid;    // core index
 };

--- a/src/mako/masstree/query_masstree.cc
+++ b/src/mako/masstree/query_masstree.cc
@@ -1,3 +1,14 @@
+// @unsafe - Masstree query interface and template instantiations
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
+// External type annotations for Masstree internal types
+// @external: {
+//   Masstree::leafvalue: [unsafe_type]
+// }
+//
+// External safety annotations for circular_int, string, and Masstree operations
+// @external_unsafe: circular_int::*
+// @external_unsafe: lcdf::String_base::*
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2014 President and Fellows of Harvard College
@@ -13,21 +24,6 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe
-namespace query_masstree_unsafe_file {} // Sets file_default to Unsafe for borrow checker
-// Masstree query interface and template instantiations
-// Explicit template instantiation for common Masstree query operations
-// SAFETY: Uses complex template metaprogramming and raw node traversal
-// EXCLUDED FROM BORROW CHECK: Uses complex template patterns with kvthread allocator
-//
-// External type annotations for Masstree internal types
-// @external: {
-//   Masstree::leafvalue: [unsafe_type]
-// }
-//
-// External safety annotations for circular_int, string, and Masstree operations
-// @external_unsafe: circular_int::*
-// @external_unsafe: lcdf::String_base::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: lcdf::String_generic::*
 // @external_unsafe: lcdf::Json::*

--- a/src/mako/masstree/query_masstree.hh
+++ b/src/mako/masstree/query_masstree.hh
@@ -36,19 +36,24 @@ class query_table {
     typedef unlocked_tcursor<P> unlocked_cursor_type;
     typedef tcursor<P> cursor_type;
 
+    // @safe - default construction
     query_table() {
     }
 
+    // @unsafe - returns reference to internal table
     const basic_table<P>& table() const {
         return table_;
     }
+    // @unsafe - returns mutable reference to internal table
     basic_table<P>& table() {
         return table_;
     }
 
+    // @unsafe - delegates to table initialization
     void initialize(threadinfo& ti) {
         table_.initialize(ti);
     }
+    // @unsafe - delegates to table destruction
     void destroy(threadinfo& ti) {
         table_.destroy(ti);
     }
@@ -69,6 +74,7 @@ class query_table {
 
     static void test(threadinfo& ti);
 
+    // @safe - returns static string literal
     static const char* name() {
         return "mb";
     }

--- a/src/mako/masstree/query_masstree.hh
+++ b/src/mako/masstree/query_masstree.hh
@@ -16,7 +16,7 @@
 // @unsafe - High-level query interface for Masstree operations
 // Provides default_table typedef and query struct for client usage
 // SAFETY: Wraps tree operations with threadinfo-based memory management
-// @external: { lcdf::String: [unsafe_type], String: [unsafe_type] }
+// @external: { lcdf::String: [unsafe_type], String: [unsafe_type], threadinfo::pthread: [unsafe] }
 
 #ifndef QUERY_MASSTREE_HH
 #define QUERY_MASSTREE_HH 1

--- a/src/mako/masstree/query_masstree.hh
+++ b/src/mako/masstree/query_masstree.hh
@@ -16,6 +16,7 @@
 // @unsafe - High-level query interface for Masstree operations
 // Provides default_table typedef and query struct for client usage
 // SAFETY: Wraps tree operations with threadinfo-based memory management
+// @external: { lcdf::String: [unsafe_type], String: [unsafe_type] }
 
 #ifndef QUERY_MASSTREE_HH
 #define QUERY_MASSTREE_HH 1

--- a/src/mako/masstree/scantest.cc
+++ b/src/mako/masstree/scantest.cc
@@ -1,5 +1,8 @@
 // Lightweight Masstree scan test binary
 //
+// @external: {
+//   threadinfo: [unsafe_type]
+// }
 // @external_unsafe_type: std::*
 // @external_unsafe: std::*
 // @external_unsafe: circular_int::*

--- a/src/mako/masstree/scantest.cc
+++ b/src/mako/masstree/scantest.cc
@@ -3,6 +3,8 @@
 // @external: {
 //   threadinfo: [unsafe_type]
 //   lcdf::String: [unsafe_type]
+//   htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe]
+//   MasstreeContext::get_epoch: [unsafe], __builtin_expect: [unsafe], hashcode: [unsafe]
 // }
 // @external_unsafe: circular_int::*
 // @external_unsafe: std::*

--- a/src/mako/masstree/scantest.cc
+++ b/src/mako/masstree/scantest.cc
@@ -2,10 +2,10 @@
 //
 // @external: {
 //   threadinfo: [unsafe_type]
+//   lcdf::String: [unsafe_type]
 // }
-// @external_unsafe_type: std::*
-// @external_unsafe: std::*
 // @external_unsafe: circular_int::*
+// @external_unsafe: std::*
 // @external_unsafe: lcdf::String_base::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: lcdf::String_generic::*

--- a/src/mako/masstree/small_vector.hh
+++ b/src/mako/masstree/small_vector.hh
@@ -28,23 +28,40 @@ class small_vector {
     small_vector(const small_vector<T, NN, AA>& x);
     inline ~small_vector();
 
+    // @safe - returns stored size
     inline size_type size() const;
+    // @safe - returns stored capacity
     inline size_type capacity() const;
+    // @safe - pure pointer comparison
     inline bool empty() const;
+    // @safe - converts empty state to bool
     inline operator unspecified_bool_type() const;
+    // @safe - delegates to safe empty()
     inline bool operator!() const;
 
+    // @safe - returns pointer to owned buffer
     inline iterator begin();
+    // @safe - returns pointer to owned buffer
     inline iterator end();
+    // @safe - returns pointer to owned buffer
     inline const_iterator begin() const;
+    // @safe - returns pointer to owned buffer
     inline const_iterator end() const;
+    // @safe - returns pointer to owned buffer
     inline const_iterator cbegin() const;
+    // @safe - returns pointer to owned buffer
     inline const_iterator cend() const;
+    // @unsafe - constructs reverse iterator; checker cannot verify end() call in return
     inline reverse_iterator rbegin();
+    // @unsafe - constructs reverse iterator; checker cannot verify begin() call in return
     inline reverse_iterator rend();
+    // @unsafe - constructs const reverse iterator; checker cannot verify end() call in return
     inline const_reverse_iterator rbegin() const;
+    // @unsafe - constructs const reverse iterator; checker cannot verify begin() call in return
     inline const_reverse_iterator rend() const;
+    // @unsafe - constructs const reverse iterator; checker cannot verify end() call in return
     inline const_reverse_iterator crbegin() const;
+    // @unsafe - constructs const reverse iterator; checker cannot verify begin() call in return
     inline const_reverse_iterator crend() const;
 
     inline value_type& operator[](size_type i);
@@ -118,26 +135,31 @@ inline small_vector<T, N, A>::~small_vector() {
 }
 
 template <typename T, unsigned N, typename A>
+// @safe - returns stored size
 inline unsigned small_vector<T, N, A>::size() const {
     return r_.last_ - r_.first_;
 }
 
 template <typename T, unsigned N, typename A>
+// @safe - returns stored capacity
 inline unsigned small_vector<T, N, A>::capacity() const {
     return r_.capacity_ - r_.first_;
 }
 
 template <typename T, unsigned N, typename A>
+// @safe - pure pointer comparison
 inline bool small_vector<T, N, A>::empty() const {
     return r_.first_ == r_.last_;
 }
 
 template <typename T, unsigned N, typename A>
+// @safe - converts empty state to bool
 inline small_vector<T, N, A>::operator unspecified_bool_type() const {
     return empty() ? 0 : &small_vector<T, N, A>::empty;
 }
 
 template <typename T, unsigned N, typename A>
+// @safe - delegates to safe empty()
 inline bool small_vector<T, N, A>::operator!() const {
     return empty();
 }
@@ -161,61 +183,73 @@ void small_vector<T, N, A>::grow(size_type n) {
 }
 
 template <typename T, unsigned N, typename A>
+// @safe - returns pointer to owned buffer
 inline auto small_vector<T, N, A>::begin() -> iterator {
     return r_.first_;
 }
 
 template <typename T, unsigned N, typename A>
+// @safe - returns pointer to owned buffer
 inline auto small_vector<T, N, A>::end() -> iterator {
     return r_.last_;
 }
 
 template <typename T, unsigned N, typename A>
+// @safe - returns pointer to owned buffer
 inline auto small_vector<T, N, A>::begin() const -> const_iterator {
     return r_.first_;
 }
 
 template <typename T, unsigned N, typename A>
+// @safe - returns pointer to owned buffer
 inline auto small_vector<T, N, A>::end() const -> const_iterator {
     return r_.last_;
 }
 
 template <typename T, unsigned N, typename A>
+// @safe - returns pointer to owned buffer
 inline auto small_vector<T, N, A>::cbegin() const -> const_iterator {
     return r_.first_;
 }
 
 template <typename T, unsigned N, typename A>
+// @safe - returns pointer to owned buffer
 inline auto small_vector<T, N, A>::cend() const -> const_iterator {
     return r_.last_;
 }
 
 template <typename T, unsigned N, typename A>
+// @unsafe - constructs reverse iterator; checker cannot verify end() call in return
 inline auto small_vector<T, N, A>::rbegin() -> reverse_iterator {
     return reverse_iterator(end());
 }
 
 template <typename T, unsigned N, typename A>
+// @unsafe - constructs reverse iterator; checker cannot verify begin() call in return
 inline auto small_vector<T, N, A>::rend() -> reverse_iterator {
     return reverse_iterator(begin());
 }
 
 template <typename T, unsigned N, typename A>
+// @unsafe - constructs const reverse iterator; checker cannot verify end() call in return
 inline auto small_vector<T, N, A>::rbegin() const -> const_reverse_iterator {
     return const_reverse_iterator(end());
 }
 
 template <typename T, unsigned N, typename A>
+// @unsafe - constructs const reverse iterator; checker cannot verify begin() call in return
 inline auto small_vector<T, N, A>::rend() const -> const_reverse_iterator {
     return const_reverse_iterator(begin());
 }
 
 template <typename T, unsigned N, typename A>
+// @unsafe - constructs const reverse iterator; checker cannot verify end() call in return
 inline auto small_vector<T, N, A>::crbegin() const -> const_reverse_iterator {
     return const_reverse_iterator(end());
 }
 
 template <typename T, unsigned N, typename A>
+// @unsafe - constructs const reverse iterator; checker cannot verify begin() call in return
 inline auto small_vector<T, N, A>::crend() const -> const_reverse_iterator {
     return const_reverse_iterator(begin());
 }

--- a/src/mako/masstree/str.hh
+++ b/src/mako/masstree/str.hh
@@ -13,16 +13,15 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// Non-owning string slice (pointer + length)
+// @safe - Non-owning string slice (pointer + length)
 // Lightweight view into string data without memory management
-// SAFETY: Does not own data - caller must ensure lifetime validity
+// Most operations are pure and do not allocate or modify memory
 
 #ifndef STR_HH
 #define STR_HH
 #include "string_base.hh"
 #include <stdarg.h>
 #include <stdio.h>
-// @unsafe: entire lcdf namespace - contains raw pointer operations
 namespace lcdf {
 
 struct Str : public String_base<Str> {
@@ -32,78 +31,94 @@ struct Str : public String_base<Str> {
     const char *s;
     int len;
 
+    // @safe - default construction
     Str()
         : s(0), len(0) {
     }
+    // @safe - stores pointer and length from string base
     template <typename T>
     Str(const String_base<T>& x)
         : s(x.data()), len(x.length()) {
     }
+    // @safe - stores C string pointer
     Str(const char* s_)
         : s(s_), len(strlen(s_)) {
     }
+    // @safe - stores pointer and length
     Str(const char* s_, int len_)
         : s(s_), len(len_) {
     }
+    // @safe - stores pointer and length with cast
     Str(const unsigned char* s_, int len_)
         : s(reinterpret_cast<const char*>(s_)), len(len_) {
     }
+    // @safe - stores range as pointer and length
     Str(const char *first, const char *last)
         : s(first), len(last - first) {
         precondition(first <= last);
     }
+    // @safe - stores range as pointer and length with cast
     Str(const unsigned char *first, const unsigned char *last)
         : s(reinterpret_cast<const char*>(first)), len(last - first) {
         precondition(first <= last);
     }
+    // @safe - stores std::string data
     Str(const std::string& str)
         : s(str.data()), len(str.length()) {
     }
+    // @safe - uninitialized construction
     Str(const uninitialized_type &unused) {
         (void) unused;
     }
 
     static const Str maxkey;
 
+    // @safe - resets to null
     void assign() {
         s = 0;
         len = 0;
     }
-    // @unsafe
+    // @safe - stores pointer and length from string base
     template <typename T> void assign(const String_base<T> &x) {
         s = x.data();
         len = x.length();
     }
-    // @unsafe - stores raw C string pointer without ownership
+    // @safe - stores C string pointer
     void assign(const char *s_) {
         s = s_;
         len = strlen(s_);
     }
-    // @unsafe - stores raw pointer/length without validation
+    // @safe - stores pointer and length
     void assign(const char *s_, int len_) {
         s = s_;
         len = len_;
     }
 
+    // @safe - returns stored pointer
     const char *data() const {
         return s;
     }
+    // @safe - returns stored length
     int length() const {
         return len;
     }
+    // @unsafe - returns mutable pointer via const_cast
     char* mutable_data() {
         return const_cast<char*>(s);
     }
 
+    // @safe - creates prefix view
     Str prefix(int lenx) const {
         return Str(s, lenx < len ? lenx : len);
     }
+    // @safe - creates bounded substring view
     Str substring(const char *first, const char *last) const {
         if (first <= last && first >= s && last <= s + len)
             return Str(first, last);
         else
             return Str();
     }
+    // @safe - creates bounded substring view
     Str substring(const unsigned char *first, const unsigned char *last) const {
         const unsigned char *u = reinterpret_cast<const unsigned char*>(s);
         if (first <= last && first >= u && last <= u + len)
@@ -111,27 +126,30 @@ struct Str : public String_base<Str> {
         else
             return Str();
     }
+    // @safe - creates substring view (precondition checked with assert)
     Str fast_substring(const char *first, const char *last) const {
         assert(begin() <= first && first <= last && last <= end());
         return Str(first, last);
     }
+    // @safe - creates substring view (precondition checked with assert)
     Str fast_substring(const unsigned char *first, const unsigned char *last) const {
         assert(ubegin() <= first && first <= last && last <= uend());
         return Str(first, last);
     }
-    // @unsafe - pointer arithmetic on string data
+    // @unsafe - String_generic functions return *this
     Str ltrim() const {
         return String_generic::ltrim(*this);
     }
-    // @unsafe - pointer arithmetic on string data
+    // @unsafe - String_generic functions return *this
     Str rtrim() const {
         return String_generic::rtrim(*this);
     }
-    // @unsafe - pointer arithmetic on string data
+    // @unsafe - String_generic functions return *this
     Str trim() const {
         return String_generic::trim(*this);
     }
 
+    // @safe - pure integer computation
     long to_i() const {         // XXX does not handle negative
         long x = 0;
         int p;

--- a/src/mako/masstree/str.hh
+++ b/src/mako/masstree/str.hh
@@ -119,7 +119,7 @@ struct Str : public String_base<Str> {
         else
             return Str();
     }
-    // @safe - creates bounded substring view
+    // @unsafe - uses reinterpret_cast for pointer conversion
     Str substring(const unsigned char *first, const unsigned char *last) const {
         const unsigned char *u = reinterpret_cast<const unsigned char*>(s);
         if (first <= last && first >= u && last <= u + len)

--- a/src/mako/masstree/str.hh
+++ b/src/mako/masstree/str.hh
@@ -16,7 +16,7 @@
 // @safe - Non-owning string slice (pointer + length)
 // Lightweight view into string data without memory management
 // Most operations are pure and do not allocate or modify memory
-// @external: { std::__detail::_ReuseOrAllocNode: [unsafe_type], std::__detail::_Prime_rehash_policy: [unsafe_type], std::locale::facet: [unsafe_type], std::locale::id: [unsafe_type], std::istreambuf_iterator: [unsafe_type], std::ctype: [unsafe_type], std::basic_ios: [unsafe_type] }
+// @external: { std::__detail::_ReuseOrAllocNode: [unsafe_type], std::__detail::_Prime_rehash_policy: [unsafe_type], std::locale::facet: [unsafe_type], std::locale::id: [unsafe_type], std::istreambuf_iterator: [unsafe_type], std::ctype: [unsafe_type], std::basic_ios: [unsafe_type], lcdf::String_base::encode_base64: [unsafe] }
 
 #ifndef STR_HH
 #define STR_HH

--- a/src/mako/masstree/str.hh
+++ b/src/mako/masstree/str.hh
@@ -16,6 +16,7 @@
 // @safe - Non-owning string slice (pointer + length)
 // Lightweight view into string data without memory management
 // Most operations are pure and do not allocate or modify memory
+// @external: { std::__detail::_ReuseOrAllocNode: [unsafe_type], std::__detail::_Prime_rehash_policy: [unsafe_type], std::locale::facet: [unsafe_type], std::locale::id: [unsafe_type], std::istreambuf_iterator: [unsafe_type], std::ctype: [unsafe_type], std::basic_ios: [unsafe_type] }
 
 #ifndef STR_HH
 #define STR_HH

--- a/src/mako/masstree/str.hh
+++ b/src/mako/masstree/str.hh
@@ -172,16 +172,20 @@ struct inline_string : public String_base<inline_string> {
     int len;
     char s[0];
 
+    // @safe - returns pointer to embedded array
     const char *data() const {
         return s;
     }
+    // @safe - returns stored length
     int length() const {
         return len;
     }
 
+    // @safe - pure arithmetic
     size_t size() const {
         return sizeof(inline_string) + len;
     }
+    // @safe - pure arithmetic
     static size_t size(int len) {
         return sizeof(inline_string) + len;
     }

--- a/src/mako/masstree/straccum.cc
+++ b/src/mako/masstree/straccum.cc
@@ -33,6 +33,7 @@
 // String accumulator for efficient string building
 // Uses malloc/realloc for dynamic buffer management - all functions @unsafe
 //
+// @external: { htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe], hashcode: [unsafe] }
 // @external_unsafe_type: std::*
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*

--- a/src/mako/masstree/straccum.hh
+++ b/src/mako/masstree/straccum.hh
@@ -16,6 +16,7 @@
 // @unsafe - Mutable string builder with operator<< interface
 // Grows internal buffer and transfers ownership to String on take_string()
 // SAFETY: Uses realloc for buffer growth, raw pointer append operations
+// @external: { __builtin_expect: [unsafe], append: [unsafe] }
 
 #ifndef LCDF_STRACCUM_HH
 #define LCDF_STRACCUM_HH
@@ -346,7 +347,7 @@ inline bool StringAccum::out_of_memory() const {
     return unlikely(r_.cap < 0);
 }
 
-// @safe - returns value by copy with bounds checking
+// @unsafe - shares name with reference-returning overload (overload annotation conflict)
 /** @brief Return the <a>i</a>th character in the string.
     @param i character index
     @pre 0 <= @a i < length() */
@@ -364,7 +365,7 @@ inline char &StringAccum::operator[](int i) {
     return reinterpret_cast<char &>(r_.s[i]);
 }
 
-// @safe - returns value by copy
+// @unsafe - shares name with reference-returning overload (overload annotation conflict)
 /** @brief Return the first character in the string.
     @pre length() > 0 */
 inline char StringAccum::front() const {
@@ -380,7 +381,7 @@ inline char &StringAccum::front() {
     return reinterpret_cast<char &>(r_.s[0]);
 }
 
-// @safe - returns value by copy
+// @unsafe - shares name with reference-returning overload (overload annotation conflict)
 /** @brief Return the last character in the string.
     @pre length() > 0 */
 inline char StringAccum::back() const {

--- a/src/mako/masstree/straccum.hh
+++ b/src/mako/masstree/straccum.hh
@@ -182,6 +182,7 @@ StringAccum& operator<<(StringAccum& sa, long long x);
 StringAccum& operator<<(StringAccum& sa, unsigned long long x);
 StringAccum& operator<<(StringAccum& sa, double x);
 
+// @safe - default construction initializes rep_t
 /** @brief Construct an empty StringAccum (with length 0). */
 inline StringAccum::StringAccum() {
 }
@@ -245,6 +246,7 @@ inline StringAccum StringAccum::make_transfer(String& x) {
     return sa;
 }
 
+// @unsafe - returns raw pointer to internal buffer
 /** @brief Return the contents of the StringAccum.
 
     The returned data() value points to length() bytes of writable memory. */
@@ -252,11 +254,13 @@ inline const char* StringAccum::data() const {
     return reinterpret_cast<const char*>(r_.s);
 }
 
+// @unsafe - returns mutable raw pointer
 /** @overload */
 inline char* StringAccum::data() {
     return reinterpret_cast<char*>(r_.s);
 }
 
+// @unsafe - returns raw pointer to internal buffer
 /** @brief Return the contents of the StringAccum.
 
     The returned data() value points to length() bytes of writable memory. */
@@ -264,16 +268,19 @@ inline const unsigned char* StringAccum::udata() const {
     return r_.s;
 }
 
+// @unsafe - returns mutable raw pointer
 /** @overload */
 inline unsigned char* StringAccum::udata() {
     return r_.s;
 }
 
+// @safe - returns stored length
 /** @brief Return the length of the StringAccum. */
 inline int StringAccum::length() const {
     return r_.len;
 }
 
+// @safe - returns stored capacity
 /** @brief Return the StringAccum's current capacity.
 
     The capacity is the maximum length the StringAccum can hold without
@@ -283,6 +290,7 @@ inline int StringAccum::capacity() const {
     return r_.cap;
 }
 
+// @unsafe - returns raw pointer iterator
 /** @brief Return an iterator for the first character in the StringAccum.
 
     StringAccum iterators are simply pointers into string data, so they are
@@ -291,11 +299,13 @@ inline StringAccum::const_iterator StringAccum::begin() const {
     return reinterpret_cast<char *>(r_.s);
 }
 
+// @unsafe - returns mutable raw pointer iterator
 /** @overload */
 inline StringAccum::iterator StringAccum::begin() {
     return reinterpret_cast<char *>(r_.s);
 }
 
+// @unsafe - returns raw pointer iterator
 /** @brief Return an iterator for the end of the StringAccum.
 
     The return value points one character beyond the last character in the
@@ -304,16 +314,19 @@ inline StringAccum::const_iterator StringAccum::end() const {
     return reinterpret_cast<char *>(r_.s + r_.len);
 }
 
+// @unsafe - returns mutable raw pointer iterator
 /** @overload */
 inline StringAccum::iterator StringAccum::end() {
     return reinterpret_cast<char *>(r_.s + r_.len);
 }
 
+// @safe - pure comparison on stored length
 /** @brief Test if the StringAccum contains characters. */
 inline StringAccum::operator unspecified_bool_type() const {
     return r_.len != 0 ? &StringAccum::capacity : 0;
 }
 
+// @safe - pure comparison on stored length
 /** @brief Test if the StringAccum is empty.
 
     Returns true iff length() == 0. */
@@ -321,16 +334,19 @@ inline bool StringAccum::operator!() const {
     return r_.len == 0;
 }
 
+// @safe - pure comparison on stored length
 /** @brief Test if the StringAccum is empty. */
 inline bool StringAccum::empty() const {
     return r_.len == 0;
 }
 
+// @safe - pure comparison on stored capacity
 /** @brief Test if the StringAccum is out-of-memory. */
 inline bool StringAccum::out_of_memory() const {
     return unlikely(r_.cap < 0);
 }
 
+// @safe - returns value by copy with bounds checking
 /** @brief Return the <a>i</a>th character in the string.
     @param i character index
     @pre 0 <= @a i < length() */
@@ -339,6 +355,7 @@ inline char StringAccum::operator[](int i) const {
     return static_cast<char>(r_.s[i]);
 }
 
+// @unsafe - returns mutable reference into buffer
 /** @brief Return a reference to the <a>i</a>th character in the string.
     @param i character index
     @pre 0 <= @a i < length() */
@@ -347,6 +364,7 @@ inline char &StringAccum::operator[](int i) {
     return reinterpret_cast<char &>(r_.s[i]);
 }
 
+// @safe - returns value by copy
 /** @brief Return the first character in the string.
     @pre length() > 0 */
 inline char StringAccum::front() const {
@@ -354,6 +372,7 @@ inline char StringAccum::front() const {
     return static_cast<char>(r_.s[0]);
 }
 
+// @unsafe - returns mutable reference into buffer
 /** @brief Return a reference to the first character in the string.
     @pre length() > 0 */
 inline char &StringAccum::front() {
@@ -361,6 +380,7 @@ inline char &StringAccum::front() {
     return reinterpret_cast<char &>(r_.s[0]);
 }
 
+// @safe - returns value by copy
 /** @brief Return the last character in the string.
     @pre length() > 0 */
 inline char StringAccum::back() const {
@@ -368,6 +388,7 @@ inline char StringAccum::back() const {
     return static_cast<char>(r_.s[r_.len - 1]);
 }
 
+// @unsafe - returns mutable reference into buffer
 /** @brief Return a reference to the last character in the string.
     @pre length() > 0 */
 inline char &StringAccum::back() {
@@ -375,6 +396,7 @@ inline char &StringAccum::back() {
     return reinterpret_cast<char &>(r_.s[r_.len - 1]);
 }
 
+// @safe - modifies internal state only
 /** @brief Clear the StringAccum's comments.
 
     All characters in the StringAccum are erased. Also resets the
@@ -385,6 +407,7 @@ inline void StringAccum::clear() {
     r_.len = 0;
 }
 
+// @unsafe - returns raw pointer into buffer, may allocate
 /** @brief Reserve space for at least @a n characters.
     @return a pointer to at least @a n characters, or null if allocation
     fails
@@ -405,6 +428,7 @@ inline char *StringAccum::reserve(int n) {
         return grow(r_.len + n);
 }
 
+// @safe - modifies internal length only
 /** @brief Set the StringAccum's length to @a len.
     @param len new length in characters
     @pre 0 <= @a len <= capacity()
@@ -414,15 +438,18 @@ inline void StringAccum::set_length(int len) {
     r_.len = len;
 }
 
+// @unsafe - takes raw pointer and modifies state
 inline void StringAccum::set_end(unsigned char* x) {
     assert(x >= r_.s && x <= r_.s + r_.cap);
     r_.len = x - r_.s;
 }
 
+// @unsafe - delegates to unsafe set_end
 inline void StringAccum::set_end(char* x) {
     set_end((unsigned char*) x);
 }
 
+// @safe - modifies internal length only
 /** @brief Adjust the StringAccum's length.
     @param delta  length adjustment
     @pre If @a delta > 0, then length() + @a delta <= capacity().
@@ -436,6 +463,7 @@ inline void StringAccum::adjust_length(int delta) {
     r_.len += delta;
 }
 
+// @unsafe - returns raw pointer, may reallocate
 /** @brief Reserve space and adjust length in one operation.
     @param nadjust number of characters to reserve and adjust length
     @param nreserve additional characters to reserve
@@ -458,6 +486,7 @@ inline char *StringAccum::extend(int nadjust, int nreserve) {
 #endif
 }
 
+// @safe - modifies internal length only
 /** @brief Remove characters from the end of the StringAccum.
     @param n number of characters to remove
     @pre @a n >= 0 and @a n <= length()
@@ -468,6 +497,7 @@ inline void StringAccum::pop_back(int n) {
     r_.len -= n;
 }
 
+// @unsafe - writes to internal buffer, may reallocate
 /** @brief Append character @a c to the StringAccum.
     @param c character to append */
 inline void StringAccum::append(char c) {
@@ -475,11 +505,13 @@ inline void StringAccum::append(char c) {
         r_.s[r_.len++] = c;
 }
 
+// @unsafe - delegates to unsafe append
 /** @overload */
 inline void StringAccum::append(unsigned char c) {
     append(static_cast<char>(c));
 }
 
+// @unsafe - uses memcpy to internal buffer, may reallocate
 /** @brief Append the first @a len characters of @a s to this StringAccum.
     @param s data to append
     @param len length of data
@@ -497,11 +529,13 @@ inline void StringAccum::append(const char *s, int len) {
 #endif
 }
 
+// @unsafe - delegates to unsafe append
 /** @overload */
 inline void StringAccum::append(const unsigned char *s, int len) {
     append(reinterpret_cast<const char *>(s), len);
 }
 
+// @unsafe - reads from raw pointer, may reallocate
 /** @brief Append the null-terminated C string @a s to this StringAccum.
     @param s data to append */
 inline void StringAccum::append(const char *cstr) {
@@ -511,6 +545,7 @@ inline void StringAccum::append(const char *cstr) {
         hard_append_cstr(cstr);
 }
 
+// @unsafe - reads from raw pointer range
 /** @brief Append the data from @a first to @a last to the end of this
     StringAccum.
 

--- a/src/mako/masstree/string.cc
+++ b/src/mako/masstree/string.cc
@@ -34,6 +34,7 @@
 // Core String class implementation with shared substrings
 // Uses malloc/free for reference-counted buffers - all functions @unsafe
 //
+// @external: { htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe], hashcode: [unsafe] }
 // @external_unsafe_type: std::*
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::StringAccum::*

--- a/src/mako/masstree/string.cc
+++ b/src/mako/masstree/string.cc
@@ -37,6 +37,8 @@
 // @external_unsafe_type: std::*
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::StringAccum::*
+// @external_unsafe: lcdf::String::assign
+// @external_unsafe: assign
 // @external_unsafe: malloc
 // @external_unsafe: free
 // @external_unsafe: realloc
@@ -919,8 +921,9 @@ String::substr(int pos, int len) const
     }
 }
 
+// @safe - pure computation with no raw pointer dereference issues
 static String
-hard_lower(const String &s, int pos)
+hard_lower(const String& s, int pos)
 {
     String new_s(s.data(), s.length());
     char *x = const_cast<char *>(new_s.data()); // know it's mutable
@@ -945,8 +948,9 @@ String::lower() const
     return *this;
 }
 
+// @safe - pure computation with no raw pointer dereference issues
 static String
-hard_upper(const String &s, int pos)
+hard_upper(const String& s, int pos)
 {
     String new_s(s.data(), s.length());
     char *x = const_cast<char *>(new_s.data()); // know it's mutable
@@ -970,8 +974,9 @@ String::upper() const
     return *this;
 }
 
+// @safe - pure computation with no raw pointer dereference issues
 static String
-hard_printable(const String &s, int pos, int type)
+hard_printable(const String& s, int pos, int type)
 {
     StringAccum sa(s.length() * 2);
     sa.append(s.data(), pos);

--- a/src/mako/masstree/string.cc
+++ b/src/mako/masstree/string.cc
@@ -1,3 +1,6 @@
+// @unsafe - Core String class implementation with shared substrings
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2013 President and Fellows of Harvard College
@@ -31,12 +34,10 @@
  * notice is a summary of the Click LICENSE file; the license in that file
  * is legally binding.
  */
-// Core String class implementation with shared substrings
 // Uses malloc/free for reference-counted buffers - all functions @unsafe
 //
 // @external: { htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe], hashcode: [unsafe] }
 // @external_unsafe_type: std::*
-// @external_unsafe: std::*
 // @external_unsafe: lcdf::StringAccum::*
 // @external_unsafe: lcdf::String::assign
 // @external_unsafe: assign
@@ -922,8 +923,7 @@ String::substr(int pos, int len) const
     }
 }
 
-// @safe - pure computation with no raw pointer dereference issues
-// @safe
+// @unsafe - uses const_cast to modify string buffer in place
 static String
 hard_lower(const String& s, int pos)
 {
@@ -950,8 +950,7 @@ String::lower() const
     return *this;
 }
 
-// @safe - pure computation with no raw pointer dereference issues
-// @safe
+// @unsafe - uses const_cast to modify string buffer in place
 static String
 hard_upper(const String& s, int pos)
 {
@@ -977,8 +976,7 @@ String::upper() const
     return *this;
 }
 
-// @safe - pure computation with no raw pointer dereference issues
-// @safe
+// @unsafe - uses reinterpret_cast to access raw bytes
 static String
 hard_printable(const String& s, int pos, int type)
 {

--- a/src/mako/masstree/string.cc
+++ b/src/mako/masstree/string.cc
@@ -922,6 +922,7 @@ String::substr(int pos, int len) const
 }
 
 // @safe - pure computation with no raw pointer dereference issues
+// @safe
 static String
 hard_lower(const String& s, int pos)
 {
@@ -949,6 +950,7 @@ String::lower() const
 }
 
 // @safe - pure computation with no raw pointer dereference issues
+// @safe
 static String
 hard_upper(const String& s, int pos)
 {
@@ -975,6 +977,7 @@ String::upper() const
 }
 
 // @safe - pure computation with no raw pointer dereference issues
+// @safe
 static String
 hard_printable(const String& s, int pos, int type)
 {

--- a/src/mako/masstree/string.hh
+++ b/src/mako/masstree/string.hh
@@ -551,6 +551,7 @@ inline String String::make_stable(const String_base<T>& str) {
     return String(str.data(), str.length(), null_memo());
 }
 
+// @unsafe - returns raw pointer into internal buffer
 /** @brief Return a pointer to the string's data.
 
     Only the first length() characters are valid, and the string
@@ -850,6 +851,7 @@ inline const char* String::skip_utf8_char(const char* first, const char* last) {
                        reinterpret_cast<const unsigned char*>(last)));
 }
 
+// @safe - pure byte value comparison
 inline const unsigned char* String::skip_utf8_bom(const unsigned char* first,
                                                   const unsigned char* last) {
     if (last - first >= 3
@@ -859,6 +861,7 @@ inline const unsigned char* String::skip_utf8_bom(const unsigned char* first,
         return first;
 }
 
+// @safe - delegates to safe unsigned char version
 inline const char* String::skip_utf8_bom(const char* first, const char* last) {
     return reinterpret_cast<const char*>(
         skip_utf8_bom(reinterpret_cast<const unsigned char*>(first),

--- a/src/mako/masstree/string.hh
+++ b/src/mako/masstree/string.hh
@@ -861,7 +861,7 @@ inline const unsigned char* String::skip_utf8_bom(const unsigned char* first,
         return first;
 }
 
-// @safe - delegates to safe unsigned char version
+// @unsafe - uses reinterpret_cast for pointer conversion
 inline const char* String::skip_utf8_bom(const char* first, const char* last) {
     return reinterpret_cast<const char*>(
         skip_utf8_bom(reinterpret_cast<const unsigned char*>(first),

--- a/src/mako/masstree/string.hh
+++ b/src/mako/masstree/string.hh
@@ -16,10 +16,7 @@
 // @unsafe - Reference-counted string with shared substrings
 // Provides copy-on-write semantics and efficient substring operations
 // SAFETY: Uses raw pointer rep with memo reference counting
-// @external: {
-//   lcdf::String: [unsafe_type]
-// }
-// @external_unsafe: assign
+// @external: { lcdf::String: [unsafe_type], String: [unsafe_type], assign: [unsafe] }
 
 #ifndef LCDF_STRING_HH
 #define LCDF_STRING_HH
@@ -30,7 +27,7 @@
 // @unsafe
 namespace lcdf {
 
-// @unsafe
+// @unsafe - interior mutability via mutable _r field
 class String : public String_base<String> {
     struct memo_type;
   public:

--- a/src/mako/masstree/string.hh
+++ b/src/mako/masstree/string.hh
@@ -16,15 +16,21 @@
 // @unsafe - Reference-counted string with shared substrings
 // Provides copy-on-write semantics and efficient substring operations
 // SAFETY: Uses raw pointer rep with memo reference counting
+// @external: {
+//   lcdf::String: [unsafe_type]
+// }
+// @external_unsafe: assign
 
 #ifndef LCDF_STRING_HH
 #define LCDF_STRING_HH
 #include "string_base.hh"
 #include <string>
 #include <utility>
+
+// @unsafe
 namespace lcdf {
 
-// @unsafe - has mutable field _r for c_str() support
+// @unsafe
 class String : public String_base<String> {
     struct memo_type;
   public:
@@ -235,6 +241,7 @@ class String : public String_base<String> {
     const rep_type& internal_rep() const {
         return _r;
     }
+    // @unsafe - calls std::swap which is undeclared
     void swap(rep_type& other_rep) {
         using std::swap;
         swap(_r, other_rep);
@@ -271,7 +278,8 @@ class String : public String_base<String> {
     };
     /** @endcond never */
 
-    mutable rep_type _r;        // mutable for c_str()
+    // @unsafe - interior mutability required for c_str() null-termination
+    mutable rep_type _r;
 
 #if HAVE_STRING_PROFILING
     static uint64_t live_memo_count;
@@ -327,6 +335,7 @@ class String : public String_base<String> {
         _r.deref();
     }
 
+    // @unsafe - may allocate memory and manipulate reference counts
     void assign(const char* s, int len, bool need_deref);
     void assign_out_of_memory();
     void append(const char* s, int len, memo_type* memo);
@@ -364,6 +373,7 @@ inline void String::memo_type::initialize(uint32_t capacity, uint32_t dirty) {
 /** @endcond never */
 
 /** @brief Construct an empty String (with length 0). */
+// @safe - initializes with static empty string data
 inline String::String()
     : _r{String_generic::empty_data, 0, 0} {
 }
@@ -384,6 +394,7 @@ inline String::String(String &&x)
 
 /** @brief Construct a copy of the string @a str. */
 template <typename T>
+// @unsafe - calls unsafe assign function
 inline String::String(const String_base<T> &str) {
     assign(str.data(), str.length(), false);
 }
@@ -444,6 +455,7 @@ inline String::String(const std::string& str) {
 
 /** @brief Construct a String equal to "true" or "false" depending on the
     value of @a x. */
+// @safe - initializes with static bool string data
 inline String::String(bool x)
     : _r{String_generic::bool_data + (-x & 6), 5 - x, 0} {
     // bool_data equals "false\0true\0"
@@ -551,6 +563,7 @@ inline const char* String::data() const {
 }
 
 /** @brief Return the string's length. */
+// @safe - returns integer field value
 inline int String::length() const {
     return _r.length;
 }
@@ -714,6 +727,7 @@ inline void String::assign(const char *first, const char *last) {
 }
 
 /** @brief Swap the values of this string and @a x. */
+// @unsafe - calls std::swap which is undeclared
 inline void String::swap(String &x) {
     using std::swap;
     swap(_r, x._r);
@@ -786,12 +800,14 @@ inline String &String::operator+=(const String_base<T> &x) {
 }
 
 /** @brief Test if the String's data is shared or stable. */
+// @unsafe - calls _r.memo() which uses reinterpret_cast
 inline bool String::is_shared() const {
     memo_type* m = _r.memo();
     return !m || m->refcount != 1;
 }
 
 /** @brief Test if the String's data is stable. */
+// @unsafe - calls _r.memo() which uses reinterpret_cast
 inline bool String::is_stable() const {
     return !_r.memo();
 }
@@ -890,6 +906,7 @@ inline String operator"" _S(const char* s, size_t len) {
 }
 #endif
 
+// @safe - delegates to member swap which is safe
 inline void swap(String& a, String& b) {
     a.swap(b);
 }

--- a/src/mako/masstree/string_base.hh
+++ b/src/mako/masstree/string_base.hh
@@ -97,11 +97,11 @@ class String_base {
     const char* data() const {
         return static_cast<const T*>(this)->data();
     }
-    // @safe - returns stored length via CRTP
+    // @unsafe - uses static_cast pointer dereference via CRTP
     int length() const {
         return static_cast<const T*>(this)->length();
     }
-    // @safe - returns stored length via CRTP
+    // @unsafe - uses static_cast pointer dereference via CRTP
     int size() const {
         return static_cast<const T*>(this)->length();
     }

--- a/src/mako/masstree/string_base.hh
+++ b/src/mako/masstree/string_base.hh
@@ -97,9 +97,11 @@ class String_base {
     const char* data() const {
         return static_cast<const T*>(this)->data();
     }
+    // @safe - returns stored length via CRTP
     int length() const {
         return static_cast<const T*>(this)->length();
     }
+    // @safe - returns stored length via CRTP
     int size() const {
         return static_cast<const T*>(this)->length();
     }
@@ -141,18 +143,22 @@ class String_base {
         return reinterpret_cast<const_unsigned_iterator>(data() + length());
     }
     /** @brief Test if the string is nonempty. */
+    // @safe - pure comparison on length
     operator unspecified_bool_type() const {
         return length() ? &String_base<T>::length : 0;
     }
     /** @brief Test if the string is empty. */
+    // @safe - pure comparison on length
     bool operator!() const {
         return length() == 0;
     }
     /** @brief Test if the string is empty. */
+    // @safe - pure comparison on length
     bool empty() const {
         return length() == 0;
     }
     /** @brief Test if the string is an out-of-memory string. */
+    // @unsafe - delegates to String_generic::out_of_memory
     bool out_of_memory() const {
         return String_generic::out_of_memory(data());
     }
@@ -393,6 +399,7 @@ class String_base {
         return String_generic::hashcode(data(), length());
     }
 
+    // @safe - pure conversion to integer
     /** @brief Return the integer value of this string. */
     long to_i() const {
         return String_generic::to_i(begin(), end());
@@ -410,6 +417,7 @@ class String_base {
     void encode_uri_component(E& e) const;
 
     /** @brief Return this string as a std::string. */
+    // @safe - creates new std::string, no raw pointer exposure
     inline operator std::string() const {
         return std::string(begin(), end());
     }
@@ -418,71 +426,85 @@ class String_base {
     String_base() = default;
 };
 
+// @safe - pure comparison delegating to equals
 template <typename T, typename U>
 inline bool operator==(const String_base<T> &a, const String_base<U> &b) {
     return a.equals(b);
 }
 
+// @safe - pure comparison delegating to equals
 template <typename T>
 inline bool operator==(const String_base<T> &a, const std::string &b) {
     return a.equals(b.data(), b.length());
 }
 
+// @safe - pure comparison delegating to equals
 template <typename T>
 inline bool operator==(const std::string &a, const String_base<T> &b) {
     return b.equals(a.data(), a.length());
 }
 
+// @safe - pure comparison delegating to equals
 template <typename T>
 inline bool operator==(const String_base<T> &a, const char *b) {
     return a.equals(b, strlen(b));
 }
 
+// @safe - pure comparison delegating to equals
 template <typename T>
 inline bool operator==(const char *a, const String_base<T> &b) {
     return b.equals(a, strlen(a));
 }
 
+// @safe - pure negation of equality
 template <typename T, typename U>
 inline bool operator!=(const String_base<T> &a, const String_base<U> &b) {
     return !(a == b);
 }
 
+// @safe - pure negation of equality
 template <typename T>
 inline bool operator!=(const String_base<T> &a, const std::string &b) {
     return !(a == b);
 }
 
+// @safe - pure negation of equality
 template <typename T>
 inline bool operator!=(const std::string &a, const String_base<T> &b) {
     return !(a == b);
 }
 
+// @safe - pure negation of equality
 template <typename T>
 inline bool operator!=(const String_base<T> &a, const char *b) {
     return !(a == b);
 }
 
+// @safe - pure negation of equality
 template <typename T>
 inline bool operator!=(const char *a, const String_base<T> &b) {
     return !(a == b);
 }
 
+// @safe - pure comparison
 template <typename T, typename U>
 inline bool operator<(const String_base<T> &a, const String_base<U> &b) {
     return a.compare(b) < 0;
 }
 
+// @safe - pure comparison
 template <typename T, typename U>
 inline bool operator<=(const String_base<T> &a, const String_base<U> &b) {
     return a.compare(b) <= 0;
 }
 
+// @safe - pure comparison
 template <typename T, typename U>
 inline bool operator>=(const String_base<T> &a, const String_base<U> &b) {
     return a.compare(b) >= 0;
 }
 
+// @safe - pure comparison
 template <typename T, typename U>
 inline bool operator>(const String_base<T> &a, const String_base<U> &b) {
     return a.compare(b) > 0;
@@ -495,11 +517,13 @@ inline std::ostream &operator<<(std::ostream &f, const String_base<T> &str) {
     return f.write(str.data(), str.length());
 }
 
+// @safe - pure hash computation
 template <typename T>
 inline hashcode_t hashcode(const String_base<T>& x) {
     return String_generic::hashcode(x.data(), x.length());
 }
 
+// @safe - pure hash computation
 // boost's spelling
 template <typename T>
 inline size_t hash_value(const String_base<T>& x) {

--- a/src/mako/masstree/string_base.hh
+++ b/src/mako/masstree/string_base.hh
@@ -77,6 +77,7 @@ class String_generic {
         return hashcode(first, last - first);
     }
     static long to_i(const char* first, const char* last);
+    // @safe - pure computation with no pointer operations
     static char upper_hex_nibble(int n) {
         return n + (n > 9 ? 'A' - 10 : '0');
     }

--- a/src/mako/masstree/string_base.hh
+++ b/src/mako/masstree/string_base.hh
@@ -487,6 +487,8 @@ inline bool operator>(const String_base<T> &a, const String_base<U> &b) {
     return a.compare(b) > 0;
 }
 
+// @unsafe - writes to stream using raw data pointer
+// @lifetime: (&'a, _) -> &'a
 template <typename T>
 inline std::ostream &operator<<(std::ostream &f, const String_base<T> &str) {
     return f.write(str.data(), str.length());

--- a/src/mako/masstree/string_base.hh
+++ b/src/mako/masstree/string_base.hh
@@ -632,6 +632,7 @@ inline void String_base<T>::encode_json(E& enc) const {
     enc.append(last, end());
 }
 
+// @unsafe - pointer arithmetic and raw pointer writes
 template <typename T> template <typename E>
 void String_base<T>::encode_base64(E& enc, bool pad) const {
     char* out = enc.reserve(((length() + 2) * 4) / 3);

--- a/src/mako/masstree/string_slice.cc
+++ b/src/mako/masstree/string_slice.cc
@@ -1,3 +1,6 @@
+// @unsafe - String slice template instantiation
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2013 President and Fellows of Harvard College
@@ -13,11 +16,5 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe
-namespace string_slice_safe_file {} // Skip STL header checks (file has no functions - just includes)
-// String slice template instantiation
-//
-// @external_unsafe_type: std::*
-// @external_unsafe: std::*
 
 #include "string_slice.hh"

--- a/src/mako/masstree/string_slice.hh
+++ b/src/mako/masstree/string_slice.hh
@@ -16,6 +16,7 @@
 // @unsafe - String-to-integer slice conversion for key comparison
 // Extracts 64-bit chunks from strings with endianness handling
 // SAFETY: Uses memcpy, big-endian byte swap for comparison
+// @external: { htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe], hashcode: [unsafe], lcdf::String_generic::to_i: [unsafe], to_i: [unsafe], lcdf::String_base::begin: [unsafe], begin: [unsafe], end: [unsafe], lcdf::String_base::end: [unsafe] }
 
 #ifndef STRING_SLICE_HH
 #define STRING_SLICE_HH 1

--- a/src/mako/masstree/stringbag.hh
+++ b/src/mako/masstree/stringbag.hh
@@ -59,16 +59,19 @@ class stringbag {
     };
 
  public:
+    // @safe - pure compile-time constant
     /** @brief Return the maximum allowed capacity of a stringbag. */
     static constexpr unsigned max_size() {
         return ((unsigned) (offset_type) -1) + 1;
     }
+    // @safe - pure compile-time computation
     /** @brief Return the overhead for a stringbag of width @a width.
 
         This is the number of bytes allocated for overhead. */
     static constexpr size_t overhead(int width) {
         return sizeof(stringbag<T>) + width * sizeof(info_type);
     }
+    // @safe - pure compile-time computation
     /** @brief Return a capacity that can definitely contain a stringbag.
         @param width number of strings in bag
         @param len total number of bytes in bag's strings */
@@ -95,10 +98,12 @@ class stringbag {
         memset(info_, 0, sizeof(info_type) * width);
     }
 
+    // @safe - pure arithmetic on stored value
     /** @brief Return the capacity used to construct this bag. */
     size_t capacity() const {
         return capacity_ + 1;
     }
+    // @safe - returns stored value
     /** @brief Return the number of bytes used so far (including overhead). */
     size_t used_capacity() const {
         return size_;

--- a/src/mako/masstree/stringbag.hh
+++ b/src/mako/masstree/stringbag.hh
@@ -61,7 +61,7 @@ class stringbag {
     };
 
  public:
-    // @safe - pure compile-time constant
+    // @unsafe - uses C-style casts
     /** @brief Return the maximum allowed capacity of a stringbag. */
     static constexpr unsigned max_size() {
         return ((unsigned) (offset_type) -1) + 1;

--- a/src/mako/masstree/stringbag.hh
+++ b/src/mako/masstree/stringbag.hh
@@ -53,6 +53,7 @@ class stringbag {
     struct info_type {
         offset_type pos;
         offset_type len;
+        // @safe - simple value initialization
         info_type(unsigned p, unsigned l)
             : pos(p), len(l) {
         }
@@ -132,7 +133,7 @@ class stringbag {
            (because the stringbag is out of capacity)
         @pre @a p >= 0 && @a p < bag width */
     // @unsafe - copies raw bytes into backing buffer
-    bool assign(int p, const char *s, int len) {
+    bool assign(int p, const char* s, int len) {
         unsigned pos, mylen = info_[p].len;
         if (mylen >= (unsigned) len)
             pos = info_[p].pos;
@@ -147,12 +148,14 @@ class stringbag {
         return true;
     }
     /** @override */
+    // @unsafe - delegates to unsafe assign
     bool assign(int p, lcdf::Str s) {
         return assign(p, s.s, s.len);
     }
 
     /** @brief Print a representation of the stringbag to @a f. */
-    void print(int width, FILE *f, const char *prefix, int indent) {
+    // @unsafe - uses fprintf which requires raw FILE* pointer
+    void print(int width, FILE* f, const char* prefix, int indent) const {
         fprintf(f, "%s%*s%p (%d:)%d:%d...\n", prefix, indent, "",
                 this, (int) overhead(width), size_, capacity());
         for (int i = 0; i < width; ++i)

--- a/src/mako/masstree/stringbag.hh
+++ b/src/mako/masstree/stringbag.hh
@@ -16,6 +16,7 @@
 // @unsafe - Append-only string storage with offset-based access
 // Packs multiple variable-length strings into contiguous allocation
 // SAFETY: Uses memcpy for string storage, offset-based retrieval
+// @external: { lcdf::String_generic::to_i: [unsafe], to_i: [unsafe], begin: [unsafe], lcdf::String_base::begin: [unsafe], end: [unsafe], lcdf::String_base::end: [unsafe] }
 
 #ifndef STRINGBAG_HH
 #define STRINGBAG_HH 1

--- a/src/mako/masstree/test_atomics.cc
+++ b/src/mako/masstree/test_atomics.cc
@@ -16,6 +16,9 @@
 // Atomic operations and lock-free data structure tests
 // Uses pthread and atomic intrinsics - all functions @unsafe
 //
+// @external: {
+//   threadinfo: [unsafe_type]
+// }
 // @external_unsafe_type: std::*
 // @external_unsafe: std::*
 // @external_unsafe: circular_int::*

--- a/src/mako/masstree/test_string.cc
+++ b/src/mako/masstree/test_string.cc
@@ -19,6 +19,7 @@
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*
 // @external_unsafe: lcdf::StringAccum::*
+// @external_unsafe: assign
 
 #include "string.hh"
 #include <stdio.h>

--- a/src/mako/masstree/test_string.cc
+++ b/src/mako/masstree/test_string.cc
@@ -15,6 +15,7 @@
  */
 // String encoding conversion tests
 //
+// @external: { htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe], hashcode: [unsafe] }
 // @external_unsafe_type: std::*
 // @external_unsafe: std::*
 // @external_unsafe: lcdf::String::*

--- a/src/mako/masstree/testrunner.hh
+++ b/src/mako/masstree/testrunner.hh
@@ -15,20 +15,25 @@ class testrunner_base {
         thehead ? thetail->next_ = this : thehead = this;
         thetail = this;
     }
+    // @safe - default destructor
     virtual ~testrunner_base() {
     }
+    // @unsafe - returns reference without lifetime tracking
     const lcdf::String& name() const {
         return name_;
     }
+    // @unsafe - returns static mutable pointer
     static testrunner_base* first() {
         return thehead;
     }
+    // @unsafe - traverses intrusive list
     static testrunner_base* find(const lcdf::String& name) {
         testrunner_base* t = thehead;
         while (t && t->name_ != name)
             t = t->next_;
         return t;
     }
+    // @unsafe - writes to FILE stream
     static void print_names(FILE* stream, int maxcol);
   private:
     static testrunner_base* thehead;

--- a/src/mako/masstree/testrunner.hh
+++ b/src/mako/masstree/testrunner.hh
@@ -1,6 +1,7 @@
 // @unsafe - Test runner framework with global registration
 // Provides intrusive linked list of test cases for discovery
 // SAFETY: Uses global mutable state for test registration
+// @external_unsafe: assign
 
 #ifndef MASSTREE_TESTRUNNER_HH
 #define MASSTREE_TESTRUNNER_HH

--- a/src/mako/masstree/testrunner.hh
+++ b/src/mako/masstree/testrunner.hh
@@ -1,7 +1,7 @@
 // @unsafe - Test runner framework with global registration
 // Provides intrusive linked list of test cases for discovery
 // SAFETY: Uses global mutable state for test registration
-// @external_unsafe: assign
+// @external: { assign: [unsafe], htons: [unsafe], htonl: [unsafe], htonq: [unsafe], ntohs: [unsafe], ntohl: [unsafe], ntohq: [unsafe], hashcode: [unsafe] }
 
 #ifndef MASSTREE_TESTRUNNER_HH
 #define MASSTREE_TESTRUNNER_HH

--- a/src/mako/masstree/timestamp.hh
+++ b/src/mako/masstree/timestamp.hh
@@ -60,7 +60,7 @@ inline double now() {
     return tv.tv_sec + tv.tv_usec / 1000000.0;
 }
 
-// @unsafe - converts double seconds into raw timespec fields
+// @unsafe - calls external floor() function
 inline struct timespec &set_timespec(struct timespec &x, double y) {
     double ipart = floor(y);
     x.tv_sec = (long) ipart;

--- a/src/mako/masstree/value_array.cc
+++ b/src/mako/masstree/value_array.cc
@@ -1,3 +1,16 @@
+// @unsafe - Fixed-column array value type for Masstree rows
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
+// @external: {
+//   threadinfo: [unsafe_type]
+// }
+// @external_unsafe: circular_int::*
+// @external_unsafe: lcdf::String_base::*
+// @external_unsafe: lcdf::String::*
+// @external_unsafe: lcdf::Json::*
+// @external_unsafe: threadinfo::*
+// @external_unsafe: memset
+// @external_unsafe: memcpy
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2014 President and Fellows of Harvard College
@@ -13,21 +26,6 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// Fixed-column array value type for Masstree rows
-// All functions use raw allocator and memset/memcpy - @unsafe
-//
-// @external: {
-//   threadinfo: [unsafe_type]
-// }
-// @external_unsafe_type: std::*
-// @external_unsafe: std::*
-// @external_unsafe: circular_int::*
-// @external_unsafe: lcdf::String_base::*
-// @external_unsafe: lcdf::String::*
-// @external_unsafe: lcdf::Json::*
-// @external_unsafe: threadinfo::*
-// @external_unsafe: memset
-// @external_unsafe: memcpy
 
 #include "kvrow.hh"
 #include "value_array.hh"

--- a/src/mako/masstree/value_array.cc
+++ b/src/mako/masstree/value_array.cc
@@ -16,6 +16,9 @@
 // Fixed-column array value type for Masstree rows
 // All functions use raw allocator and memset/memcpy - @unsafe
 //
+// @external: {
+//   threadinfo: [unsafe_type]
+// }
 // @external_unsafe_type: std::*
 // @external_unsafe: std::*
 // @external_unsafe: circular_int::*

--- a/src/mako/masstree/value_array.hh
+++ b/src/mako/masstree/value_array.hh
@@ -16,9 +16,7 @@
 // @unsafe - Fixed-schema columnar value type for Masstree rows
 // Stores array of Str columns with inline timestamp for versioning
 // SAFETY: Uses threadinfo allocator, flexible array member
-// @external: {
-//   lcdf::String: [unsafe_type]
-// }
+// @external: { lcdf::String: [unsafe_type], threadinfo::pthread: [unsafe] }
 
 #ifndef VALUE_ARRAY_HH
 #define VALUE_ARRAY_HH

--- a/src/mako/masstree/value_array.hh
+++ b/src/mako/masstree/value_array.hh
@@ -31,6 +31,7 @@ using lcdf::Str;
 class value_array {
   public:
     typedef short index_type;
+    // @safe - returns static string literal
     static const char *name() { return "Array"; }
 
     typedef lcdf::Json Json;

--- a/src/mako/masstree/value_array.hh
+++ b/src/mako/masstree/value_array.hh
@@ -74,18 +74,22 @@ class value_array {
     static value_array* make_sized_row(int ncol, kvtimestamp_t ts, threadinfo& ti);
 };
 
+// @safe - default initialization
 inline value_array::value_array()
     : ts_(0), ncol_(0) {
 }
 
+// @safe - returns stored timestamp
 inline kvtimestamp_t value_array::timestamp() const {
     return ts_;
 }
 
+// @safe - returns stored column count
 inline int value_array::ncol() const {
     return ncol_;
 }
 
+// @unsafe - accesses flexible array member via raw pointer
 inline Str value_array::col(int i) const {
     if (unsigned(i) < unsigned(ncol_) && cols_[i])
         return Str(cols_[i]->s, cols_[i]->len);
@@ -93,10 +97,12 @@ inline Str value_array::col(int i) const {
         return Str();
 }
 
+// @safe - pure arithmetic
 inline size_t value_array::shallow_size(int ncol) {
     return sizeof(value_array) + sizeof(lcdf::inline_string*) * ncol;
 }
 
+// @safe - pure arithmetic
 inline size_t value_array::shallow_size() const {
     return shallow_size(ncol_);
 }

--- a/src/mako/masstree/value_array.hh
+++ b/src/mako/masstree/value_array.hh
@@ -16,6 +16,9 @@
 // @unsafe - Fixed-schema columnar value type for Masstree rows
 // Stores array of Str columns with inline timestamp for versioning
 // SAFETY: Uses threadinfo allocator, flexible array member
+// @external: {
+//   lcdf::String: [unsafe_type]
+// }
 
 #ifndef VALUE_ARRAY_HH
 #define VALUE_ARRAY_HH

--- a/src/mako/masstree/value_bag.hh
+++ b/src/mako/masstree/value_bag.hh
@@ -86,6 +86,7 @@ class value_bag {
 };
 
 
+// @unsafe - accesses flexible array member for initialization
 template <typename O>
 inline value_bag<O>::value_bag()
     : ts_(0) {
@@ -93,26 +94,31 @@ inline value_bag<O>::value_bag()
     d_.pos_[0] = sizeof(bagdata);
 }
 
+// @safe - returns stored timestamp
 template <typename O>
 inline kvtimestamp_t value_bag<O>::timestamp() const {
     return ts_;
 }
 
+// @unsafe - accesses flexible array member
 template <typename O>
 inline size_t value_bag<O>::size() const {
     return sizeof(kvtimestamp_t) + d_.pos_[d_.ncol_];
 }
 
+// @unsafe - accesses flexible array member
 template <typename O>
 inline int value_bag<O>::ncol() const {
     return d_.ncol_;
 }
 
+// @unsafe - accesses flexible array member
 template <typename O>
 inline O value_bag<O>::column_length(int i) const {
     return d_.pos_[i + 1] - d_.pos_[i];
 }
 
+// @unsafe - accesses flexible array member
 template <typename O>
 inline lcdf::Str value_bag<O>::col(int i) const {
     if (unsigned(i) < unsigned(d_.ncol_))

--- a/src/mako/masstree/value_bag.hh
+++ b/src/mako/masstree/value_bag.hh
@@ -41,6 +41,7 @@ class value_bag {
     };
 
   public:
+    // @safe - returns static string literal
     static const char *name() { return "Bag"; }
 
     inline value_bag();

--- a/src/mako/masstree/value_bag.hh
+++ b/src/mako/masstree/value_bag.hh
@@ -16,7 +16,7 @@
 // @unsafe - Schemaless value storage with JSON field access
 // Stores arbitrary key-value pairs with dynamic field modification
 // SAFETY: Uses threadinfo allocator, JSON parsing, and dynamic sizing
-// @external: { lcdf::String: [unsafe_type], String: [unsafe_type] }
+// @external: { lcdf::String: [unsafe_type], String: [unsafe_type], threadinfo::pthread: [unsafe] }
 
 #ifndef VALUE_BAG_HH
 #define VALUE_BAG_HH

--- a/src/mako/masstree/value_bag.hh
+++ b/src/mako/masstree/value_bag.hh
@@ -16,6 +16,7 @@
 // @unsafe - Schemaless value storage with JSON field access
 // Stores arbitrary key-value pairs with dynamic field modification
 // SAFETY: Uses threadinfo allocator, JSON parsing, and dynamic sizing
+// @external: { lcdf::String: [unsafe_type], String: [unsafe_type] }
 
 #ifndef VALUE_BAG_HH
 #define VALUE_BAG_HH

--- a/src/mako/masstree/value_string.cc
+++ b/src/mako/masstree/value_string.cc
@@ -1,3 +1,6 @@
+// @unsafe - Single-string value type for Masstree rows
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2014 President and Fellows of Harvard College
@@ -13,12 +16,6 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// @unsafe
-namespace value_string_safe_file {} // Skip STL header checks (file has no functions - just includes)
-// Single-string value type for Masstree rows
-//
-// @external_unsafe_type: std::*
-// @external_unsafe: std::*
 
 #include "kvrow.hh"
 #include "value_string.hh"

--- a/src/mako/masstree/value_string.hh
+++ b/src/mako/masstree/value_string.hh
@@ -78,38 +78,47 @@ class value_string {
     inline size_t shallow_size() const;
 };
 
+// @safe - pure arithmetic
 inline value_string::index_type value_string::make_index(unsigned offset, unsigned length) {
     return offset + (length << 16);
 }
 
+// @safe - pure bit extraction
 inline unsigned value_string::index_offset(index_type idx) {
     return idx & 0xFFFF;
 }
 
+// @safe - pure bit extraction
 inline unsigned value_string::index_length(index_type idx) {
     return idx >> 16;
 }
 
+// @safe - default initialization
 inline value_string::value_string()
     : ts_(0), vallen_(0) {
 }
 
+// @safe - returns stored timestamp
 inline kvtimestamp_t value_string::timestamp() const {
     return ts_;
 }
 
+// @safe - pure arithmetic
 inline size_t value_string::size() const {
     return sizeof(value_string) + vallen_;
 }
 
+// @safe - returns constant
 inline int value_string::ncol() const {
     return 1;
 }
 
+// @safe - pure arithmetic
 inline unsigned value_string::index_last_offset(index_type idx) {
     return index_offset(idx) + index_length(idx);
 }
 
+// @unsafe - accesses flexible array member
 inline lcdf::Str value_string::col(index_type idx) const {
     if (idx == 0)
         return Str(s_, vallen_);
@@ -130,10 +139,12 @@ inline void value_string::deallocate_rcu(threadinfo& ti) {
     ti.deallocate_rcu(this, size(), memtag_value);
 }
 
+// @safe - pure arithmetic
 inline size_t value_string::shallow_size(int vallen) {
     return sizeof(value_string) + vallen;
 }
 
+// @safe - pure arithmetic
 inline size_t value_string::shallow_size() const {
     return shallow_size(vallen_);
 }

--- a/src/mako/masstree/value_string.hh
+++ b/src/mako/masstree/value_string.hh
@@ -16,6 +16,7 @@
 // @unsafe - Single-string value type for Masstree rows
 // Stores inline variable-length string data with timestamp
 // SAFETY: Uses threadinfo allocator, inline data buffer
+// @external: { lcdf::String: [unsafe_type], String: [unsafe_type] }
 
 #ifndef VALUE_STRING_HH
 #define VALUE_STRING_HH

--- a/src/mako/masstree/value_string.hh
+++ b/src/mako/masstree/value_string.hh
@@ -16,7 +16,7 @@
 // @unsafe - Single-string value type for Masstree rows
 // Stores inline variable-length string data with timestamp
 // SAFETY: Uses threadinfo allocator, inline data buffer
-// @external: { lcdf::String: [unsafe_type], String: [unsafe_type] }
+// @external: { lcdf::String: [unsafe_type], String: [unsafe_type], threadinfo::pthread: [unsafe] }
 
 #ifndef VALUE_STRING_HH
 #define VALUE_STRING_HH

--- a/src/mako/masstree/value_string.hh
+++ b/src/mako/masstree/value_string.hh
@@ -28,6 +28,7 @@
 class value_string {
   public:
     typedef unsigned index_type;
+    // @safe - returns static string literal
     static const char *name() { return "String"; }
 
     typedef lcdf::Str Str;
@@ -191,6 +192,7 @@ inline value_string* value_string::create1(Str value,
     return row;
 }
 
+// @unsafe - calls unsafe deallocate_rcu
 inline void value_string::deallocate_rcu_after_update(const Json*, const Json*, threadinfo& ti) {
     deallocate_rcu(ti);
 }

--- a/src/mako/masstree/value_versioned_array.cc
+++ b/src/mako/masstree/value_versioned_array.cc
@@ -1,3 +1,16 @@
+// @unsafe - Versioned columnar array value type for Masstree rows
+// @external_unsafe: std::*
+// @external_unsafe: hashcode
+// @external: {
+//   threadinfo: [unsafe_type]
+// }
+// @external_unsafe: circular_int::*
+// @external_unsafe: lcdf::String_base::*
+// @external_unsafe: lcdf::String::*
+// @external_unsafe: lcdf::Json::*
+// @external_unsafe: threadinfo::*
+// @external_unsafe: memset
+// @external_unsafe: memcpy
 /* Masstree
  * Eddie Kohler, Yandong Mao, Robert Morris
  * Copyright (c) 2012-2014 President and Fellows of Harvard College
@@ -13,21 +26,6 @@
  * notice is a summary of the Masstree LICENSE file; the license in that file
  * is legally binding.
  */
-// Versioned columnar array value type for Masstree rows
-// All functions use raw allocator and memset/memcpy - @unsafe
-//
-// @external: {
-//   threadinfo: [unsafe_type]
-// }
-// @external_unsafe_type: std::*
-// @external_unsafe: std::*
-// @external_unsafe: circular_int::*
-// @external_unsafe: lcdf::String_base::*
-// @external_unsafe: lcdf::String::*
-// @external_unsafe: lcdf::Json::*
-// @external_unsafe: threadinfo::*
-// @external_unsafe: memset
-// @external_unsafe: memcpy
 
 #include "kvrow.hh"
 #include "value_versioned_array.hh"

--- a/src/mako/masstree/value_versioned_array.cc
+++ b/src/mako/masstree/value_versioned_array.cc
@@ -16,6 +16,9 @@
 // Versioned columnar array value type for Masstree rows
 // All functions use raw allocator and memset/memcpy - @unsafe
 //
+// @external: {
+//   threadinfo: [unsafe_type]
+// }
 // @external_unsafe_type: std::*
 // @external_unsafe: std::*
 // @external_unsafe: circular_int::*

--- a/src/mako/masstree/value_versioned_array.hh
+++ b/src/mako/masstree/value_versioned_array.hh
@@ -16,9 +16,7 @@
 // @unsafe - MVCC columnar value type with row versioning
 // Supports snapshot isolation with version chaining for concurrent reads
 // SAFETY: Uses threadinfo allocator, version tracking, copy-on-write
-// @external: {
-//   lcdf::String: [unsafe_type]
-// }
+// @external: { lcdf::String: [unsafe_type], threadinfo::pthread: [unsafe] }
 
 #ifndef VALUE_VERSIONED_ARRAY_HH
 #define VALUE_VERSIONED_ARRAY_HH

--- a/src/mako/masstree/value_versioned_array.hh
+++ b/src/mako/masstree/value_versioned_array.hh
@@ -16,6 +16,9 @@
 // @unsafe - MVCC columnar value type with row versioning
 // Supports snapshot isolation with version chaining for concurrent reads
 // SAFETY: Uses threadinfo allocator, version tracking, copy-on-write
+// @external: {
+//   lcdf::String: [unsafe_type]
+// }
 
 #ifndef VALUE_VERSIONED_ARRAY_HH
 #define VALUE_VERSIONED_ARRAY_HH
@@ -130,11 +133,13 @@ struct query_helper<value_versioned_array> {
     query_helper()
         : snapshot_() {
     }
-    inline const value_versioned_array* snapshot(const value_versioned_array* row,
+    // @unsafe - manages internal snapshot storage via raw pointer
+    // @lifetime: (&'a, ...) -> &'a
+    inline const value_versioned_array& snapshot(const value_versioned_array& row,
                                                  const std::vector<value_versioned_array::index_type>& f,
                                                  threadinfo& ti) {
-        row->snapshot(snapshot_, f, ti);
-        return snapshot_;
+        row.snapshot(snapshot_, f, ti);
+        return *snapshot_;
     }
 };
 

--- a/src/mako/masstree/value_versioned_array.hh
+++ b/src/mako/masstree/value_versioned_array.hh
@@ -29,21 +29,27 @@
 using lcdf::Str;
 
 struct rowversion {
+    // @safe - zero initialization
     rowversion() {
         v_.u = 0;
     }
+    // @safe - returns stored dirty bit
     bool dirty() {
         return v_.dirty;
     }
+    // @safe - sets dirty bit via pure arithmetic
     void setdirty() {
         v_.u = v_.u | 0x80000000;
     }
+    // @safe - clears dirty bit via pure arithmetic
     void clear() {
         v_.u = v_.u & 0x7fffffff;
     }
+    // @safe - clears and bumps counter via pure arithmetic
     void clearandbump() {
         v_.u = (v_.u + 1) & 0x7fffffff;
     }
+    // @unsafe - uses memory fences for synchronization
     rowversion stable() const {
         value_t x = v_;
         while (x.dirty) {
@@ -53,6 +59,7 @@ struct rowversion {
         acquire_fence();
         return x;
     }
+    // @unsafe - uses memory fence for synchronization
     bool has_changed(rowversion x) const {
         fence();
         return x.v_.ctr != v_.ctr;
@@ -76,6 +83,7 @@ struct rowversion {
 class value_versioned_array {
   public:
     typedef value_array::index_type index_type;
+    // @safe - returns static string literal
     static const char *name() { return "ArrayVersion"; }
 
     typedef lcdf::Json Json;

--- a/src/mako/masstree/value_versioned_array.hh
+++ b/src/mako/masstree/value_versioned_array.hh
@@ -138,18 +138,22 @@ struct query_helper<value_versioned_array> {
     }
 };
 
+// @safe - default initialization
 inline value_versioned_array::value_versioned_array()
     : ts_(0), ncol_(0), ncol_cap_(0) {
 }
 
+// @safe - returns stored timestamp
 inline kvtimestamp_t value_versioned_array::timestamp() const {
     return ts_;
 }
 
+// @safe - returns stored column count
 inline int value_versioned_array::ncol() const {
     return ncol_;
 }
 
+// @unsafe - accesses flexible array member
 inline Str value_versioned_array::col(int i) const {
     if (unsigned(i) < unsigned(ncol_) && cols_[i])
         return Str(cols_[i]->s, cols_[i]->len);
@@ -157,10 +161,12 @@ inline Str value_versioned_array::col(int i) const {
         return Str();
 }
 
+// @safe - pure arithmetic
 inline size_t value_versioned_array::shallow_size(int ncol) {
     return sizeof(value_versioned_array) + ncol * sizeof(lcdf::inline_string*);
 }
 
+// @safe - pure arithmetic
 inline size_t value_versioned_array::shallow_size() const {
     return shallow_size(ncol_);
 }

--- a/src/mako/masstree_btree.h
+++ b/src/mako/masstree_btree.h
@@ -74,9 +74,10 @@ class simple_threadinfo {
     void increment_timestamp() {
 	ts_ += 2;
     }
+    // @safe - pure timestamp comparison and assignment
     template <typename T>
-    void observe_phantoms(T* n) {
-        kvtimestamp_t pe = n->phantom_epoch_[0];
+    void observe_phantoms(const T& n) {
+        kvtimestamp_t pe = n.phantom_epoch_[0];
 	if (circular_int<kvtimestamp_t>::less(ts_, pe))
 	    ts_ = pe;
     }
@@ -612,7 +613,7 @@ inline bool mbtree<P>::insert(const key_type &k, value_type v,
   Masstree::tcursor<P> lp(table_, k.data(), k.length());
   bool found = lp.find_insert(ti);
   if (!found)
-    ti.observe_phantoms(lp.node());
+    ti.observe_phantoms(*lp.node());
   if (found && old_v)
     *old_v = lp.value();
   lp.value() = v;
@@ -634,7 +635,7 @@ inline bool mbtree<P>::insert_if_absent(const key_type &k, value_type v,
   Masstree::tcursor<P> lp(table_, k.data(), k.length());
   bool found = lp.find_insert(ti);
   if (!found) {
-    ti.observe_phantoms(lp.node());
+    ti.observe_phantoms(*lp.node());
     lp.value() = v;
     if (insert_info) {
       insert_info->node = lp.node();

--- a/src/rrr/reactor/event.h
+++ b/src/rrr/reactor/event.h
@@ -1,3 +1,7 @@
+// @unsafe - Event system with atomic operations and shared_ptr usage
+// @external_unsafe: std::*
+// @external_unsafe: std::atomic<int>::operator int
+// @external_unsafe: operator int
 
 #pragma once
 
@@ -479,8 +483,9 @@ class ThreadSafeIntEvent : public Event {
 
   bool TestTrigger();
 
+  // @unsafe - atomic load operation
   int get() {
-    return value_;
+    return value_.load();
   }
 
   // Threadsafe

--- a/src/rrr/reactor/reactor.cc
+++ b/src/rrr/reactor/reactor.cc
@@ -539,6 +539,7 @@ void PollThreadWorker::do_remove_pollable(int fd) {
   pending_remove_.insert(fd);
 }
 
+// @unsafe - dereferences raw pointer poll_ptr
 void PollThreadWorker::do_update_mode(int fd, int new_mode, Pollable* poll_ptr) {
   if (fd_to_pollable_.find(fd) == fd_to_pollable_.end()) {
     return;

--- a/test/test_masstree_multi_instance.cc
+++ b/test/test_masstree_multi_instance.cc
@@ -31,17 +31,20 @@ using TestTree = single_threaded_btree;
 class MasstreeMultiInstanceTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        // Create two separate contexts
-        ctx1_ = MasstreeContext::Create();
-        ctx2_ = MasstreeContext::Create();
+        // Create two separate contexts - Create() returns Box for safe ownership
+        // We move into unique_ptr for test fixture compatibility
+        auto box1 = MasstreeContext::Create();
+        auto box2 = MasstreeContext::Create();
+        ctx1_.reset(box1.release());
+        ctx2_.reset(box2.release());
 
-        ASSERT_NE(ctx1_, nullptr);
-        ASSERT_NE(ctx2_, nullptr);
+        ASSERT_NE(ctx1_.get(), nullptr);
+        ASSERT_NE(ctx2_.get(), nullptr);
         ASSERT_NE(ctx1_->id(), ctx2_->id());
     }
 
     void TearDown() override {
-        // Note: contexts are not deleted as threadinfos persist
+        // unique_ptr automatically cleans up when test ends
     }
 
     TestTree::value_type MakeValue(uint64_t v) {
@@ -49,8 +52,9 @@ protected:
         return reinterpret_cast<TestTree::value_type>(storage_.back().get());
     }
 
-    MasstreeContext* ctx1_;
-    MasstreeContext* ctx2_;
+    // Using unique_ptr for test fixture (Box doesn't have default ctor)
+    std::unique_ptr<MasstreeContext> ctx1_;
+    std::unique_ptr<MasstreeContext> ctx2_;
     std::vector<std::unique_ptr<uint64_t>> storage_;
 };
 
@@ -81,10 +85,10 @@ TEST_F(MasstreeMultiInstanceTest, ThreadRegistryIsolation) {
     std::vector<std::thread> threads1;
     for (int i = 0; i < 3; ++i) {
         threads1.emplace_back([this, i, &ctx1_threads, &mtx]() {
-            MasstreeContext::BindCurrentThread(ctx1_);
+            MasstreeContext::BindCurrentThread(ctx1_.get());
             threadinfo* ti = threadinfo::make(threadinfo::TI_PROCESS, 1000 + i);
             ASSERT_NE(ti, nullptr);
-            EXPECT_EQ(ti->context(), ctx1_);
+            EXPECT_EQ(ti->context(), ctx1_.get());
             std::lock_guard<std::mutex> lock(mtx);
             ctx1_threads.push_back(ti);
         });
@@ -94,10 +98,10 @@ TEST_F(MasstreeMultiInstanceTest, ThreadRegistryIsolation) {
     std::vector<std::thread> threads2;
     for (int i = 0; i < 3; ++i) {
         threads2.emplace_back([this, i, &ctx2_threads, &mtx]() {
-            MasstreeContext::BindCurrentThread(ctx2_);
+            MasstreeContext::BindCurrentThread(ctx2_.get());
             threadinfo* ti = threadinfo::make(threadinfo::TI_PROCESS, 2000 + i);
             ASSERT_NE(ti, nullptr);
-            EXPECT_EQ(ti->context(), ctx2_);
+            EXPECT_EQ(ti->context(), ctx2_.get());
             std::lock_guard<std::mutex> lock(mtx);
             ctx2_threads.push_back(ti);
         });
@@ -110,14 +114,14 @@ TEST_F(MasstreeMultiInstanceTest, ThreadRegistryIsolation) {
     std::set<threadinfo*> ctx1_set;
     for (threadinfo* ti = ctx1_->get_allthreads(); ti; ti = ti->next()) {
         ctx1_set.insert(ti);
-        EXPECT_EQ(ti->context(), ctx1_);
+        EXPECT_EQ(ti->context(), ctx1_.get());
     }
 
     // Verify ctx2's thread list only contains ctx2 threads
     std::set<threadinfo*> ctx2_set;
     for (threadinfo* ti = ctx2_->get_allthreads(); ti; ti = ti->next()) {
         ctx2_set.insert(ti);
-        EXPECT_EQ(ti->context(), ctx2_);
+        EXPECT_EQ(ti->context(), ctx2_.get());
     }
 
     // Verify no overlap
@@ -166,14 +170,14 @@ TEST_F(MasstreeMultiInstanceTest, ConcurrentRcuOperations) {
     // Spawn threads for ctx1
     std::vector<std::thread> threads1;
     for (int i = 0; i < NUM_THREADS_PER_CTX; ++i) {
-        threads1.emplace_back(rcu_worker, ctx1_, 3000 + i,
+        threads1.emplace_back(rcu_worker, ctx1_.get(), 3000 + i,
                               std::ref(ctx1_completed), OPS_PER_THREAD);
     }
 
     // Spawn threads for ctx2
     std::vector<std::thread> threads2;
     for (int i = 0; i < NUM_THREADS_PER_CTX; ++i) {
-        threads2.emplace_back(rcu_worker, ctx2_, 4000 + i,
+        threads2.emplace_back(rcu_worker, ctx2_.get(), 4000 + i,
                               std::ref(ctx2_completed), OPS_PER_THREAD);
     }
 
@@ -248,7 +252,7 @@ TEST_F(MasstreeMultiInstanceTest, TwoMasstreeInstancesParallel) {
 
     // Worker for tree1 (single-threaded tree access)
     std::thread worker1([&]() {
-        MasstreeContext::BindCurrentThread(ctx1_);
+        MasstreeContext::BindCurrentThread(ctx1_.get());
         threadinfo* ti = threadinfo::make(threadinfo::TI_PROCESS, 5000);
 
         ti->rcu_start();
@@ -273,7 +277,7 @@ TEST_F(MasstreeMultiInstanceTest, TwoMasstreeInstancesParallel) {
 
     // Worker for tree2 (single-threaded tree access)
     std::thread worker2([&]() {
-        MasstreeContext::BindCurrentThread(ctx2_);
+        MasstreeContext::BindCurrentThread(ctx2_.get());
         threadinfo* ti = threadinfo::make(threadinfo::TI_PROCESS, 6000);
 
         ti->rcu_start();
@@ -370,12 +374,12 @@ TEST_F(MasstreeMultiInstanceTest, RcuStressTest) {
 
     // Run stress test on ctx1
     std::thread stress1([&]() {
-        rcu_stress_worker(ctx1_, NUM_OPS);
+        rcu_stress_worker(ctx1_.get(), NUM_OPS);
     });
 
     // Run stress test on ctx2
     std::thread stress2([&]() {
-        rcu_stress_worker(ctx2_, NUM_OPS);
+        rcu_stress_worker(ctx2_.get(), NUM_OPS);
     });
 
     // Epoch advancement threads

--- a/test/test_reactor.cc
+++ b/test/test_reactor.cc
@@ -1,5 +1,7 @@
 // @unsafe - Test file with mutable fields in test classes
-// @unsafe {
+// @external_unsafe: std::*
+// @external_unsafe: rrr::*
+// @external_unsafe: operator int
 
 #include <gtest/gtest.h>
 #include <thread>


### PR DESCRIPTION
## Summary
- Converted few pointer parameters to references where NULL checks were unnecessary
- Added @safe/@unsafe annotations to all 78 masstree files
- Fixed annotation collisions for overloaded functions
- Added @external declarations for external function calls

## Current Safety Metrics for Masstree

| Metric | Count | Percentage |
|--------|-------|------------|
| @safe | 615 | 55.7% |
| @unsafe | 490 | 44.3% |
