### PR TITLE
CI flakes: reserve harness port bands from ephemeral allocator; drain follower replay before teardown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,19 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user root
+      # --sysctl: keep kernel-assigned ephemeral source ports away from every
+      # band the test harness listens on. The suite's fixed/randomized listen
+      # ports (static paxos 45xxx + ctrl 55xxx, static raft ctrl 37xxx, raw
+      # dbtest configs up to 35100, randomized paxos/raft 40000..64535) sit
+      # inside Linux's default ephemeral range (32768-60999); an outbound
+      # connect() can grab one as its source port (or self-connect to it),
+      # and the later listener bind() dies with EADDRINUSE even under
+      # SO_REUSEADDR — the dominant mako-dev CI flake. Reserved ports are
+      # still bindable explicitly; the allocator just skips them. Ephemeral
+      # pool left: 35101-36999 + 37401-39999 (~4.5k ports, loopback
+      # tcp_tw_reuse keeps that plenty). NOTE: value must stay space-free —
+      # the runner splits `options` on whitespace.
+      options: --user root --sysctl net.ipv4.ip_local_reserved_ports=32768-35100,37000-37400,40000-64999
     timeout-minutes: 180
     strategy:
       fail-fast: false
@@ -63,6 +75,13 @@ jobs:
           echo "CMAKE_GENERATOR=${CMAKE_GENERATOR}"
           echo "MAKO_CPU_LIMIT=${MAKO_CPU_LIMIT}"
           echo "MAKO_THROTTLE_CYCLE_MS=${MAKO_THROTTLE_CYCLE_MS}"
+          # Fail loud if the container was created without the reserved-port
+          # sysctl (see container.options above): an empty value here means
+          # test listen ports are back inside the ephemeral range and the
+          # EADDRINUSE flake family is live again.
+          echo "ip_local_port_range=$(cat /proc/sys/net/ipv4/ip_local_port_range)"
+          echo "ip_local_reserved_ports=$(cat /proc/sys/net/ipv4/ip_local_reserved_ports)"
+          grep -q "40000" /proc/sys/net/ipv4/ip_local_reserved_ports
           rustc --version
           cargo --version
           cmake --version

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -120,11 +120,12 @@ cleanup_processes() {
     pkill -9 -u "$user_name" -f "bash/shard.sh" 2>/dev/null || true
 
     # Evict ANY of our processes still LISTENING in the test port
-    # ranges (20000-31699 shard/simpleTransaction band, 40000-55999
-    # paxos/raft band). The kill-by-name list above cannot enumerate
-    # every server binary (e.g. leaked rrr test servers), and a single
-    # live squatter mid-range EADDRINUSE-panics a later suite — the
-    # port picker can only probe what is free at PICK time.
+    # ranges (20000-31699 shard/simpleTransaction band, 40000-64999
+    # paxos/raft band — randomized bases reach ~54535 and their +10000
+    # heartbeat ports ~64535). The kill-by-name list above cannot
+    # enumerate every server binary (e.g. leaked rrr test servers), and
+    # a single live squatter mid-range EADDRINUSE-panics a later suite —
+    # the port picker can only probe what is free at PICK time.
     while read -r pid; do
         [ -z "$pid" ] && continue
         if is_ancestor_pid "$pid"; then continue; fi
@@ -134,7 +135,7 @@ cleanup_processes() {
         ss -ltnpH 2>/dev/null | awk '
             {
                 n = split($4, a, ":"); lp = a[n] + 0
-                if ((lp >= 20000 && lp <= 31699) || (lp >= 40000 && lp <= 55999)) print $0
+                if ((lp >= 20000 && lp <= 31699) || (lp >= 40000 && lp <= 64999)) print $0
             }' | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u
     )
 

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -43,6 +43,19 @@ if docker info --format '{{json .SecurityOptions}}' 2>/dev/null | grep -q "name=
     # Rust tooling (cargo/rustc) can fail under restrictive AppArmor profiles.
     DOCKER_SECURITY_OPTS=(--security-opt apparmor=unconfined)
 fi
+# Keep kernel-assigned ephemeral source ports away from the bands the test
+# harness listens on: paxos/raft listen ports live inside the Linux default
+# ephemeral range (32768-60999), and an outbound connect() that grabs one as
+# its source port EADDRINUSE-aborts a later server bind even under
+# SO_REUSEADDR. Reserved ports stay bindable explicitly; only the automatic
+# allocator skips them. Mirrors the CI container sysctl in
+# .github/workflows/ci.yml — keep the two lists in sync.
+# Real docker only: podman's --sysctl CSV-splits the value on commas and
+# rejects the range list (verified podman 5.x); podman runs keep the
+# historical exposure and rely on the rrr self-connect guard.
+if docker --version 2>/dev/null | grep -q '^Docker version'; then
+    DOCKER_SECURITY_OPTS+=(--sysctl net.ipv4.ip_local_reserved_ports=32768-35100,37000-37400,40000-64999)
+fi
 HAS_TTY=1
 DOCKER_INTERACTIVE_OPTS=(-it)
 COMPOSE_EXEC_OPTS=()

--- a/examples/simple_transaction_rep_port_utils.sh
+++ b/examples/simple_transaction_rep_port_utils.sh
@@ -149,8 +149,14 @@ make_simple_txn_rep_config() {
 #   shard i ports = base + i*1000 + cluster*100 + partition
 # where cluster ∈ {0=localhost, 1=p1, 2=p2, 3=learner} and partition ∈ [0, nthreads).
 # Probe leader port of each cluster on each shard (so 4 * nshards bind attempts).
-# Keeps the range out of the simpleTransaction band (20000-31699) and clear of
-# the Linux default ephemeral range (32768+).
+# Keeps the range out of the simpleTransaction band (20000-31699). NOTE: unlike
+# that band, this one sits INSIDE the Linux default ephemeral range
+# (32768-60999) — it cannot fit below 32768 because the +10000 heartbeat ports
+# would land in the simpleTransaction band. Bind-probing only proves a port is
+# free at PICK time; a later outbound connect() can still steal it as its
+# source port. In CI the container reserves these bands from the ephemeral
+# allocator (net.ipv4.ip_local_reserved_ports, see .github/workflows/ci.yml);
+# elsewhere the rrr self-connect guard removes the worst failure mode.
 pick_paxos_replication_port_base() {
     local nshards="${1:-2}"
     local nthreads="${2:-3}"

--- a/examples/test_1shard_replication.sh
+++ b/examples/test_1shard_replication.sh
@@ -4,7 +4,7 @@
 # Each shard should:
 # 1. Show "agg_persist_throughput" keyword
 # 2. Have NewOrder_remote_abort_ratio < 20%, or N/A when no remote txns occur
-# 3. Followers replay at least 1000 batches
+# 3. Followers drain and replay the leader's log (> MAKO_REPLAY_BATCH_MIN batches)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/simple_transaction_rep_port_utils.sh"
@@ -164,22 +164,46 @@ fi
 # and killing mid-lag snapshots an arbitrary replay_batch count (CI
 # saw 256/478 vs the >500 check on slow shared runners — the check's
 # intent is "replication works", not "follower keeps up in real
-# time"). Poll the p1 log until the counter clears the threshold or
-# the grace budget expires; the later checks still enforce the
-# threshold itself.
+# time"). Progress-aware: keep waiting while the counter still
+# advances (throttled CI replays a few batches/sec, so a fixed budget
+# races the backlog size), stop early once it clears the threshold,
+# and bail if it stalls — frozen means drained-or-stuck, and waiting
+# longer can't change the verdict. wait_for_termination (mako.hh) now
+# keeps logging replay_batch while draining, so a stall is a real
+# signal, not the logger going silent.
 log_p1_drain="${script_name}_shard0-p1-$trd.log"
-drain_budget="${MAKO_REPLAY_DRAIN_SECONDS:-45}"
+drain_budget="${MAKO_REPLAY_DRAIN_SECONDS:-240}"
+drain_stall_budget="${MAKO_REPLAY_DRAIN_STALL_SECONDS:-20}"
+# Threshold on the follower's replay_batch counter. Intent: "replication
+# works", not a throughput bar — now that the follower drains its backlog
+# before teardown, the counter converges to the LEADER's total batch
+# production, which under the CI CPU throttle has been observed as low as
+# ~530 (green runs: 529/766). 500 left no margin for slower runners; 200
+# still requires substantial replay while tolerating leader-side variance.
+replay_min="${MAKO_REPLAY_BATCH_MIN:-200}"
 drained=0
+last_rb=""
+stall=0
 for ((i = 0; i < drain_budget; i++)); do
     rb=$(grep "replay_batch:" "$log_p1_drain" 2>/dev/null | tail -1 | sed -n 's/.*replay_batch:\([0-9]*\).*/\1/p')
-    if [ -n "$rb" ] && [ "$rb" -gt 500 ]; then
+    if [ -n "$rb" ] && [ "$rb" -gt "$replay_min" ]; then
         echo "Follower replay drained: replay_batch=$rb after ${i}s"
         drained=1
         break
     fi
+    if [ -n "$rb" ] && [ "$rb" != "$last_rb" ]; then
+        last_rb="$rb"
+        stall=0
+    else
+        stall=$((stall + 1))
+    fi
+    if [ "$stall" -ge "$drain_stall_budget" ]; then
+        echo "Note: follower replay stalled at ${rb:-none} for ${drain_stall_budget}s (${i}s total) - giving up drain"
+        break
+    fi
     sleep 1
 done
-if [ "$drained" -eq 0 ]; then
+if [ "$drained" -eq 0 ] && [ "$stall" -lt "$drain_stall_budget" ]; then
     echo "Note: follower replay still below threshold after ${drain_budget}s grace (last: ${rb:-none})"
 fi
 
@@ -287,18 +311,19 @@ else
     else
         # Extract the replay_batch number (assuming format: "replay_batch:XXX")
         replay_count=$(echo "$last_replay_batch" | sed -n 's/.*replay_batch:\([0-9]*\).*/\1/p')
-        
+
         if [ -z "$replay_count" ]; then
             echo "  ✗ Could not extract replay_batch value"
             echo "    Last line: $last_replay_batch"
             failed=1
         else
-            # Check if replay_count is greater than 500 (lowered from 1000 to account for CI variability)
-            # The test verifies replication is working, not exact batch count
-            if [ "$replay_count" -gt 500 ]; then
-                echo "  ✓ replay_batch: $replay_count (> 500)"
+            # The test verifies replication is working, not exact batch count.
+            # Threshold rationale at the drain loop above (default 200,
+            # override via MAKO_REPLAY_BATCH_MIN).
+            if [ "$replay_count" -gt "${replay_min:-200}" ]; then
+                echo "  ✓ replay_batch: $replay_count (> ${replay_min:-200})"
             else
-                echo "  ✗ replay_batch: $replay_count (should be > 500)"
+                echo "  ✗ replay_batch: $replay_count (should be > ${replay_min:-200})"
                 failed=1
             fi
         fi

--- a/examples/test_1shard_replication_raft.sh
+++ b/examples/test_1shard_replication_raft.sh
@@ -66,6 +66,45 @@ if [ $wait_count -ge $max_wait ]; then
     echo "Warning: Benchmark did not complete within ${max_wait}s timeout"
 fi
 
+# Give the follower a grace window to DRAIN REPLAY LAG before we kill it —
+# same treatment as test_1shard_replication.sh: killing the moment the
+# leader finishes snapshots an arbitrary mid-lag replay_batch count.
+# Progress-aware: wait while the counter still advances (wait_for_termination
+# keeps logging it while draining), stop early once it clears the threshold,
+# bail on a stall (drained-or-stuck).
+log_p1_drain="${script_name}_shard0-p1-$trd.log"
+drain_budget="${MAKO_REPLAY_DRAIN_SECONDS:-240}"
+drain_stall_budget="${MAKO_REPLAY_DRAIN_STALL_SECONDS:-20}"
+# Threshold rationale: see test_1shard_replication.sh — after draining, the
+# counter converges to the leader's total batch production (observed as low
+# as ~530 under the CI CPU throttle), so >500 left no margin.
+replay_min="${MAKO_REPLAY_BATCH_MIN:-200}"
+drained=0
+last_rb=""
+stall=0
+for ((i = 0; i < drain_budget; i++)); do
+    rb=$(grep "replay_batch:" "$log_p1_drain" 2>/dev/null | tail -1 | sed -n 's/.*replay_batch:\([0-9]*\).*/\1/p')
+    if [ -n "$rb" ] && [ "$rb" -gt "$replay_min" ]; then
+        echo "Follower replay drained: replay_batch=$rb after ${i}s"
+        drained=1
+        break
+    fi
+    if [ -n "$rb" ] && [ "$rb" != "$last_rb" ]; then
+        last_rb="$rb"
+        stall=0
+    else
+        stall=$((stall + 1))
+    fi
+    if [ "$stall" -ge "$drain_stall_budget" ]; then
+        echo "Note: follower replay stalled at ${rb:-none} for ${drain_stall_budget}s (${i}s total) - giving up drain"
+        break
+    fi
+    sleep 1
+done
+if [ "$drained" -eq 0 ] && [ "$stall" -lt "$drain_stall_budget" ]; then
+    echo "Note: follower replay still below threshold after ${drain_budget}s grace (last: ${rb:-none})"
+fi
+
 # Graceful shutdown: SIGTERM first
 echo "Stopping shards (graceful)..."
 pkill -TERM -f "dbtest.*shard-index 0" 2>/dev/null || true
@@ -163,12 +202,13 @@ else
             echo "    Last line: $last_replay_batch"
             failed=1
         else
-            # Check if replay_count is greater than 500 (lowered from 1000 to account for CI variability)
-            # The test verifies replication is working, not exact batch count
-            if [ "$replay_count" -gt 500 ]; then
-                echo "  ✓ replay_batch: $replay_count (> 500)"
+            # The test verifies replication is working, not exact batch count.
+            # Threshold rationale at the drain loop above (default 200,
+            # override via MAKO_REPLAY_BATCH_MIN).
+            if [ "$replay_count" -gt "${replay_min:-200}" ]; then
+                echo "  ✓ replay_batch: $replay_count (> ${replay_min:-200})"
             else
-                echo "  ✗ replay_batch: $replay_count (should be > 500)"
+                echo "  ✗ replay_batch: $replay_count (should be > ${replay_min:-200})"
                 failed=1
             fi
         fi

--- a/src/mako/mako.hh
+++ b/src/mako/mako.hh
@@ -535,6 +535,60 @@ static void wait_for_termination()
     //if (benchConfig.getEndReceived() > 0) {std::quick_exit( EXIT_SUCCESS );}
   }
 
+  // Drain the replay backlog before tearing down. The loop above exits on
+  // the FIRST partition's END marker, but each partition replays
+  // synchronously inside its own delivery callback — the other partitions'
+  // batch tails may still be undelivered (on throttled CI runners,
+  // hundreds of batches), and watermark-parked entries drain on later
+  // deliveries. Also keep printing the counter: the CI harness reads
+  // "replay_batch:N" from this log, and going silent here made it
+  // snapshot a stale mid-lag value (the shard1Replication mako-dev flake).
+  // Exit once the counter stops advancing for a few seconds (drained or
+  // genuinely stuck) or the overall budget runs out.
+  int drain_stall_limit = 5;
+  if (const char* env = getenv("MAKO_FOLLOWER_DRAIN_STALL_SECONDS")) {
+    char* endptr = nullptr;
+    long parsed = strtol(env, &endptr, 10);
+    if (endptr != env && *endptr == '\0' && parsed > 0 && parsed <= 600) {
+      drain_stall_limit = static_cast<int>(parsed);
+    } else {
+      Warning("Invalid MAKO_FOLLOWER_DRAIN_STALL_SECONDS='%s'; using default %d",
+              env, drain_stall_limit);
+    }
+  }
+  int drain_max_seconds = 120;
+  if (const char* env = getenv("MAKO_FOLLOWER_DRAIN_MAX_SECONDS")) {
+    char* endptr = nullptr;
+    long parsed = strtol(env, &endptr, 10);
+    if (endptr != env && *endptr == '\0' && parsed > 0 && parsed <= 3600) {
+      drain_max_seconds = static_cast<int>(parsed);
+    } else {
+      Warning("Invalid MAKO_FOLLOWER_DRAIN_MAX_SECONDS='%s'; using default %d",
+              env, drain_max_seconds);
+    }
+  }
+  int last_replay_batch = benchConfig.getReplayBatch();
+  int drain_stall = 0;
+  for (int drain_time = 1; drain_time <= drain_max_seconds; drain_time++) {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    int rb = benchConfig.getReplayBatch();
+    if (rb != last_replay_batch) {
+      last_replay_batch = rb;
+      drain_stall = 0;
+    } else {
+      drain_stall++;
+    }
+    Notice("%s draining replay backlog: %d/%zu ended, replay_batch:%d, stall:%ds, drain_time:%ds\n",
+           isLearner ? "learner" : "follower",
+           benchConfig.getEndReceived(), benchConfig.getNthreads(),
+           rb, drain_stall, drain_time);
+    if (drain_stall >= drain_stall_limit) {
+      Notice("%s replay drained: replay_batch:%d stable for %ds after %ds\n",
+             isLearner ? "learner" : "follower", rb, drain_stall, drain_time);
+      break;
+    }
+  }
+
   // Track and report latency if configured if tracked
   run_latency_tracking();
 }

--- a/src/rrr/rpc/tcp_channel.cpp
+++ b/src/rrr/rpc/tcp_channel.cpp
@@ -1437,6 +1437,31 @@ ConnectResult TcpFactory::connect(std::string_view addr) {
         }
     }
 
+    // TCP self-connect guard. Connecting over loopback to a port inside
+    // the kernel's ephemeral range while no listener is bound yet can
+    // have the kernel pick source port == destination port, and TCP
+    // simultaneous-open then ESTABLISHes the socket to itself. The
+    // phantom connection (a) exchanges frames with itself and (b) squats
+    // the server's listen port, so the later bind() dies EADDRINUSE even
+    // under SO_REUSEADDR. A real peer connection can never have an
+    // identical local and remote endpoint, so refuse it; reporting
+    // ConnectionRefused makes callers retry exactly like a not-yet-up
+    // server, and the retry draws a fresh source port.
+    {
+        sockaddr_in local_sa;
+        socklen_t local_len = sizeof(local_sa);
+        // @unsafe — system call
+        if (::getsockname(fd, reinterpret_cast<sockaddr*>(&local_sa),
+                          &local_len) == 0 &&
+            local_len == sizeof(local_sa) &&
+            local_sa.sin_port == sa.sin_port &&
+            local_sa.sin_addr.s_addr == sa.sin_addr.s_addr) {
+            ::close(fd);
+            return ConnectResult{rusty::None,
+                                 ChannelError::ConnectionRefused};
+        }
+    }
+
     // Build the TcpConnection and register its pollable proxy with
     // the poll thread before returning. The channel proxy keeps one
     // Arc; the pollable proxy keeps another, so the connection


### PR DESCRIPTION
Fix the two CI flake families that killed the last two mako-dev merge runs (PR #75, PR #77)

## Why mako-dev is red

Neither merge broke anything: both merge commits' trees are **byte-identical** to their PR branch heads, which passed CI minutes before (e.g. `40b9a6ba` green at 04:37, identical tree `44b93eec` red at 04:59). mako-dev has been red since May 21 on a rotating cast of flaky-infrastructure failures; the two that killed the merge runs are fixed here.

## Family 1: `EADDRINUSE` on harness listen ports (killed the PR #77 run)

`simplePaxos` p1 died binding `0.0.0.0:45102` — `AddressInUse` — while 45101/45103 bound fine in the same millisecond, as the first process of the test, right after cleanup.

Root cause: the paxos/raft listen ports (static `45xxx` + ctrl `55xxx`, randomized `40000+`, raw dbtest configs `33000-34100`) sit **inside Linux's default ephemeral source-port range (32768-60999)**. Any outbound `connect()` in the container can be assigned one of them as its source port. Two concrete killers, both reproduced locally with a socket demo:

- kill -9'd tests leave orphaned loopback sockets in FIN_WAIT_2 on random ephemeral ports for ~60s — those defeat `SO_REUSEADDR` (only TIME_WAIT is exempt);
- TCP self-connect: `connect()` to a not-yet-bound loopback port can pick source==dest and simultaneous-open ESTABLISHes the socket **to itself** — pinning the port indefinitely and leaving a client that talks to itself.

Existing mitigations (bind-probing at pick time, listener eviction, REUSEADDR) structurally cannot catch a source-port steal: it isn't a listener and doesn't exist yet at probe time.

Fixes:
- **ci.yml**: create the job container with `--sysctl net.ipv4.ip_local_reserved_ports=32768-35100,37000-37400,40000-64999` — the allocator can no longer hand test-band ports to outbound connections; explicit binds still work. The Environments step asserts the sysctl took effect (fails loud, not silently flaky).
- **rrr `TcpFactory::connect`**: refuse self-connects (`getsockname()==getpeername()`), returning `ConnectionRefused` so the normal retry path draws a fresh source port. Protects non-CI environments too; this is the only kernel `connect(2)` site left in rrr.
- **docker_build.sh**: same sysctl for local Docker runs (real docker only — podman CSV-splits `--sysctl` values on commas and rejects the list).
- **ci.sh**: widen the leftover-listener eviction band 40000-55999 → 40000-64999 (randomized ctrl ports reach ~64535).

## Family 2: `replay_batch: 317 (should be > 500)` (killed the PR #75 run)

The follower's `wait_for_termination` exits on the **first** of nthreads partition END markers (the code checks `> 0`; the log line prints "1/3" as if all were required). Each partition replays synchronously inside its own delivery callback, so quitting on the first END abandons the other partitions' undelivered tails — under the CI's 5% CPU throttle, hundreds of batches. Worse, after that loop nothing prints `replay_batch:` anymore, so the drain added in d3db0126 polled a **log that had gone silent** and snapshotted a stale mid-lag value (317 frozen for 45s in the failing run).

Fixes:
- **mako.hh**: after the END-wait loop, keep the process alive while `replay_batch` still advances, printing the counter once per second (restores harness observability). Exits when the counter is stable for 5s (`MAKO_FOLLOWER_DRAIN_STALL_SECONDS`) or after 120s (`MAKO_FOLLOWER_DRAIN_MAX_SECONDS`). Benefits all replicated suites, not just this one.
- **test_1shard_replication.sh**: the harness drain is now progress-aware — waits while the counter advances (up to 240s), stops early on threshold or on a 20s stall.
- **Threshold 500 → 200** (`MAKO_REPLAY_BATCH_MIN`): with the drain in place the counter converges to the leader's *total* batch production, observed as low as ~530 (paxos) and **439 (raft)** under the CI throttle — 500 left no/negative margin. The check's intent is "replication works" (the 2-shard siblings assert `> 0`).

## Not addressed (pre-existing, noted for the record)

- dbtest leader segfault during SIGTERM teardown (`bash/shard.sh: line 94`) — visible in the PR #75 run log after results were already written; doesn't gate any check.
- The `MasstreeMultiInstanceTest.ConcurrentRcuOperations` flake seen on 07-01 was already fixed by 6bc8b964 (in PR #75).

## Validation

- Full clang-21 Release build green.
- Local (host): `ci.sh rrrTests` (ctest, erpc excluded), `simplePaxos.sh`, and `test_1shard_replication.sh` under the CI throttle (`MAKO_CPU_LIMIT=5`, 3 threads) — pass; follower log shows the new `draining replay backlog` lines and the drain completing.
- Kernel mechanism demos: self-connect ESTABLISHED + listener `EADDRINUSE` under `SO_REUSEADDR` reproduced with plain sockets.
- The `--sysctl` container option is validated by this PR's own CI run (the Environments step asserts it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Addendum (4th commit)

`test_1shard_replication_raft.sh` (the raft twin CI actually invokes) had the identical exposure — same `>500` check, and no drain at all. Ported the same progress-aware drain and threshold. This one was a guaranteed eventual failure: a fully-drained, fully-correct throttled run totals **439** batches (raft produces fewer batches than paxos), i.e. below the old threshold; the ci.sh 2-attempt retry has been masking it.
